### PR TITLE
fix: 🐛 overlay visibility

### DIFF
--- a/sdks/web-sdk/src/App.svelte
+++ b/sdks/web-sdk/src/App.svelte
@@ -52,6 +52,7 @@
     width: 100%;
     margin: 0 auto;
     height: 100%;
+    overflow: hidden;
   }
 
   :global(html, body, #app) {


### PR DESCRIPTION
photo overlay not visible below app borders