### PR TITLE
Bug - Android blank camera feed issue

### DIFF
--- a/sdks/web-sdk/src/Routes.svelte
+++ b/sdks/web-sdk/src/Routes.svelte
@@ -36,7 +36,7 @@
       in:fly={{ x: -50, duration: 250, delay: 300 }}
       out:fly={{ x: -50, duration: 250 }}
     >
-      <svelte:component this={step.component} stepId={stepId} />
+      <svelte:component this={step.component} {stepId} />
     </div>
   {/key}
 {/if}

--- a/sdks/web-sdk/src/lib/organisms/DocumentOptions/DocumentOptions.svelte
+++ b/sdks/web-sdk/src/lib/organisms/DocumentOptions/DocumentOptions.svelte
@@ -32,7 +32,6 @@
     const option = documentOptionsConfiguration.options[type];
     $selectedDocumentInfo = option?.document as IDocumentInfo;
     try {
-      await navigator.mediaDevices.getUserMedia({ video: true });
       goToNextStep(currentStepId, $configuration, $currentStepId);
     } catch (error) {
       $currentParams = { message: 'Camera not found or access is not provided' };

--- a/sdks/web-sdk/src/lib/pages/DocumentStart.svelte
+++ b/sdks/web-sdk/src/lib/pages/DocumentStart.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { T } from '../contexts/translation';
-  import { Image, Button, Title, Paragraph, IconButton } from '../atoms';
-  import { configuration, Steps } from '../contexts/configuration';
+  import { Button, IconButton, Image, Paragraph, Title } from '../atoms';
+  import { configuration } from '../contexts/configuration';
   import { goToNextStep, goToPrevStep } from '../contexts/navigation/hooks';
   import { Elements, IStepConfiguration } from '../contexts/configuration/types';
   import { makeStylesFromConfiguration } from '../utils/css-utils';
-  import { IDocument, currentStepId, DocumentType } from '../contexts/app-state';
+  import { currentStepId, DocumentType, IDocument } from '../contexts/app-state';
   import { isNativeCamera } from '../contexts/flows/hooks';
   import { addDocument, ICameraEvent, nativeCameraHandler } from '../utils/photo-utils';
   import { currentParams, documents, selectedDocumentInfo } from '../contexts/app-state/stores';
@@ -15,7 +15,6 @@
   export let stepId;
 
   const step = merge(documentStartStep, $configuration.steps[stepId]) as IStepConfiguration;
-  
 
   const style = makeStylesFromConfiguration(merge(layout, $configuration.layout), step.style);
 
@@ -25,11 +24,10 @@
   $: {
     if (!documentType) goToPrevStep(currentStepId, $configuration, $currentStepId);
   }
-  const stepNamespace = `${step.namespace }.${documentType}`;
+  const stepNamespace = `${step.namespace}.${documentType}`;
 
   const handleGoToNextStep = async () => {
     try {
-      await navigator.mediaDevices.getUserMedia({ video: true });
       goToNextStep(currentStepId, $configuration, $currentStepId);
     } catch (error) {
       $currentParams = { message: 'Camera not found or access is not provided' };
@@ -104,9 +102,11 @@
     background: var(--background);
     text-align: center;
   }
+
   .button-container {
     position: relative;
   }
+
   .camera-input {
     position: absolute;
     width: 100%;


### PR DESCRIPTION
### Description
On some android devices the calls to navigator.mediaDevices.getUserMedia caused the device to be in use, resulting in a blank camera feed.

### Related issues

### Breaking changes

### How these changes were tested
 * Repeated the flow a number of times on a device where the issue reproduces

### Examples and references

### Checklist
- [X] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [X] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and errors
- [X] New and existing tests pass locally with my changes
