### PR TITLE
Adds the user address fields

### DIFF
--- a/apps/backoffice/src/mock-service-worker/users/interfaces.ts
+++ b/apps/backoffice/src/mock-service-worker/users/interfaces.ts
@@ -38,6 +38,15 @@ export interface IUser {
     id_check: EState;
     selfie_check: EState;
   };
+  address: {
+    city: string;
+    country: string;
+    street: string;
+    // Could be 21 A.
+    house_num: string;
+    apt_num: string;
+    zip_code: string;
+  };
   // Array of images
   documents: Array<{
     url: string;

--- a/apps/backoffice/src/mock-service-worker/users/users.data.ts
+++ b/apps/backoffice/src/mock-service-worker/users/users.data.ts
@@ -101,6 +101,14 @@ export let data = {
         selfie_check: generateState(),
         scanned_by: 'IDV Vendor',
       },
+      address: {
+        city: faker.address.city(),
+        country,
+        street: faker.address.streetAddress().replace(/\d/g, '').trim(),
+        house_num: faker.datatype.number({ min: 1, max: 100 }).toString(),
+        apt_num: faker.datatype.number({ min: 1, max: 100 }).toString(),
+        zip_code: faker.address.zipCode(),
+      },
       documents: mockDocumentSets[Math.floor(Math.random() * mockDocumentSets.length)],
     };
   }),

--- a/apps/backoffice/src/pages/users/components/SubjectContent.tsx
+++ b/apps/backoffice/src/pages/users/components/SubjectContent.tsx
@@ -403,7 +403,7 @@ export const SubjectContent: FunctionComponent<ISubjectContentProps> = ({ nextId
                 <DetailsGrid title={'Address'} data={addressDetails}>
                   {({ text, title, ...rest }) => (
                     <DataField
-                      title={title}
+                      title={title.replace(/^apt/i, 'Apt.')}
                       text={text}
                       sx={{
                         textTransform: 'capitalize',

--- a/apps/backoffice/src/pages/users/components/SubjectContent.tsx
+++ b/apps/backoffice/src/pages/users/components/SubjectContent.tsx
@@ -1,7 +1,7 @@
 import relativeTime from 'dayjs/plugin/relativeTime';
 import React, { FunctionComponent, useEffect, useRef } from 'react';
 import { CanAccess, useTranslate } from '@pankod/refine-core';
-import { Box, Button, Divider, Group, HoverCard, Skeleton, Stack, Title } from '@pankod/refine-mantine';
+import { Button, Divider, Group, HoverCard, Skeleton, Stack, Title } from '@pankod/refine-mantine';
 import { ActionIcon, Center, Flex, Kbd, Loader, Transition } from '@mantine/core';
 import { DetailsGrid } from '../../../molecules/DetailsGrid/DetailsGrid';
 import { WarningAlert } from '../../../components/atoms/WarningAlert/WarningAlert';
@@ -51,7 +51,7 @@ export const SubjectContent: FunctionComponent<ISubjectContentProps> = ({ nextId
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   const { id = '' } = routerProvider.useParams() as { id: string };
   const { isFetching, isLoading } = useUserQuery(id);
-  const { personalDetails, passportDetails, checkResults, images } = useMockData();
+  const { personalDetails, passportDetails, checkResults, addressDetails, images } = useMockData();
   const selfieRef = useRef<HTMLImageElement | null>(null);
   const docFaceRef = useRef<HTMLImageElement | null>(null);
   // For OCR.
@@ -399,6 +399,18 @@ export const SubjectContent: FunctionComponent<ISubjectContentProps> = ({ nextId
                       />
                     );
                   }}
+                </DetailsGrid>
+                <DetailsGrid title={'Address'} data={addressDetails}>
+                  {({ text, title, ...rest }) => (
+                    <DataField
+                      title={title}
+                      text={text}
+                      sx={{
+                        textTransform: 'capitalize',
+                      }}
+                      {...rest}
+                    />
+                  )}
                 </DetailsGrid>
               </Stack>
               <Stack

--- a/apps/backoffice/src/pages/users/components/SubjectList/index.ts
+++ b/apps/backoffice/src/pages/users/components/SubjectList/index.ts
@@ -1,1 +1,1 @@
-export { SubjectList } from "./SubjectList";
+export { SubjectList } from './SubjectList';

--- a/apps/backoffice/src/pages/users/hooks/index.tsx
+++ b/apps/backoffice/src/pages/users/hooks/index.tsx
@@ -59,6 +59,16 @@ export const useMockData = () => {
     selfieCheck,
   };
 
+  // Address
+  const addressDetails = {
+    city: 'Tel-Aviv',
+    country: 'Israel',
+    street: 'Malkey Yisrael',
+    houseNumber: '2',
+    aptNumber: '31',
+    zipCode: '66882791',
+  };
+
   // Images
   const images =
     data?.documents?.map(({ url, doctype: docType }) => ({
@@ -70,6 +80,7 @@ export const useMockData = () => {
     passportDetails,
     checkResults,
     personalDetails,
+    addressDetails,
     images,
   };
 };

--- a/apps/backoffice/src/pages/users/hooks/index.tsx
+++ b/apps/backoffice/src/pages/users/hooks/index.tsx
@@ -60,13 +60,14 @@ export const useMockData = () => {
   };
 
   // Address
+  const { city, country, street, house_num: houseNum, apt_num: aptNum, zip_code: zipCode } = data?.address ?? {};
   const addressDetails = {
-    city: 'Tel-Aviv',
-    country: 'Israel',
-    street: 'Malkey Yisrael',
-    houseNumber: '2',
-    aptNumber: '31',
-    zipCode: '66882791',
+    city,
+    country,
+    street,
+    houseNum,
+    aptNum,
+    zipCode,
   };
 
   // Images

--- a/apps/backoffice/src/pages/users/show.tsx
+++ b/apps/backoffice/src/pages/users/show.tsx
@@ -3,7 +3,6 @@ import { MarkdownField, Show, Text, Title } from '@pankod/refine-mantine';
 
 import { ICategory, IPost } from 'interfaces';
 
-//
 export const UsersShow: React.FC = () => {
   const t = useTranslate();
 

--- a/apps/backoffice/src/pages/users/show.tsx
+++ b/apps/backoffice/src/pages/users/show.tsx
@@ -1,8 +1,9 @@
-import { useShow, useOne, useTranslate } from '@pankod/refine-core';
-import { Show, Title, Text, MarkdownField } from '@pankod/refine-mantine';
+import { useOne, useShow, useTranslate } from '@pankod/refine-core';
+import { MarkdownField, Show, Text, Title } from '@pankod/refine-mantine';
 
 import { ICategory, IPost } from 'interfaces';
 
+//
 export const UsersShow: React.FC = () => {
   const t = useTranslate();
 


### PR DESCRIPTION
### Description
Figma has a section for the user's address, this PR adds the mocks and the UI fields to consume the data.

### Related issues

### Breaking changes

### How these changes were tested
 * Local development server, verified behaviour and visuals in Chrome.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [X] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [X] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [--] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and errors
- [X] New and existing tests pass locally with my changes
