### PR TITLE
WIP - Fix the image items aspect ratio

### DIFF
--- a/apps/backoffice/src/App.tsx
+++ b/apps/backoffice/src/App.tsx
@@ -39,6 +39,7 @@ LightTheme.colors!.primary = [
   '#3ba1c5',
   '#2596be',
 ];
+
 function App() {
   const [colorScheme, setColorScheme] = useLocalStorage<ColorScheme>({
     key: 'mantine-color-scheme',
@@ -144,6 +145,7 @@ function App() {
               rightIcon={<IconStar color="yellow" fill="yellow" size={14} />}
               component="a"
               href="https://github.com/ballerine-io/ballerine/"
+              target={'_blank'}
               style={{
                 position: 'fixed',
                 bottom: '50px',

--- a/apps/backoffice/src/components/organisms/ImageViewer/ImageItem/ImageItem.tsx
+++ b/apps/backoffice/src/components/organisms/ImageViewer/ImageItem/ImageItem.tsx
@@ -65,7 +65,7 @@ export const ImageItem: FunctionComponent<IImageItemProps> = props => {
           alt={alt}
           {...restImage}
         />
-        <span style={{ fontSize: '12px', color:'#000000' }}>{caption}</span>
+        <span style={{ fontSize: '12px', color: '#000000' }}>{caption}</span>
       </Button>
     </List.Item>
   );

--- a/apps/backoffice/src/pages/users/components/SubjectContent.tsx
+++ b/apps/backoffice/src/pages/users/components/SubjectContent.tsx
@@ -266,16 +266,18 @@ export const SubjectContent: FunctionComponent<ISubjectContentProps> = ({ nextId
                     <BallerineImage
                       ref={selfieRef}
                       alt={'User avatar 1'}
+                      src={images?.find(({ docType }) => docType === 'Selfie')?.url ?? ''}
                       width={114}
                       height={143}
-                      src={images?.find(({ docType }) => docType === 'Selfie')?.url ?? ''}
+                      fit={'cover'}
                     />
                     <BallerineImage
                       ref={docFaceRef}
                       alt={'User avatar 2'}
+                      src={images?.find(({ docType }) => docType === 'ID Document (Face)')?.url ?? ''}
                       width={114}
                       height={143}
-                      src={images?.find(({ docType }) => docType === 'ID Document (Face)')?.url ?? ''}
+                      fit={'cover'}
                     />
                   </Flex>
                   <Group style={{ marginTop: '1.5rem' }} position="left" spacing="xl">


### PR DESCRIPTION
### Description
Currently the image items used for face comparison don't respect the image's original aspect ratio, this PR aims to make the images not look stretched.

### Related issues.

### Breaking changes

### How these changes were tested
 * Visually tested if the images are still stretched.

### Examples and references

### Checklist
- [x] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [x] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [o] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and errors
- [] New and existing tests pass locally with my changes
