### PR TITLE
Fix: typo in english translation

### DIFF
--- a/sdks/web-sdk/src/lib/configuration/translation.json
+++ b/sdks/web-sdk/src/lib/configuration/translation.json
@@ -59,7 +59,7 @@
       },
       "voter_id": {
         "title": "Voter ID front side",
-        "description": "Place your voter card inside the frome and take a picture. \nMake sure it is not cut or has any glare."
+        "description": "Place your voter card inside the frame and take a picture. \nMake sure it is not cut or has any glare."
       },
       "drivers_license": {
         "title": "Drivers license",
@@ -223,7 +223,7 @@
       "passport-title": "es: Passport",
       "passport-description": "es: Place your passport inside the frame and take a \npicture. \nMake sure it is not cut or has any glare.",
       "voter_id-title": "es: Voter ID front side",
-      "voter_id-description": "es: Place your voter card inside the frome and take a picture. \nMake sure it is not cut or has any glare.",
+      "voter_id-description": "es: Place your voter card inside the frame and take a picture. \nMake sure it is not cut or has any glare.",
       "drivers_license-title": "es: Drivers license",
       "drivers_license-description": "es: Place your drivers license inside the frame and take \na picture. \nMake sure it is not cut or has any glare.",
       "proof_of_business_tax_id-title": "TIN ID / Certificate",


### PR DESCRIPTION
"Place your voter card inside the frome" - 'frome' instead of frame

### Description
Typo in English translation of web SDK. "frome" instead of "frame".

### How these changes were tested
 * Run a flow locally to check the updated translation.
 * Node version: v14.18.0
 * MacBook Pro 2017
 * MacOS Big Sur v11.6.5
 * Chrome v108.0.5359.94 (Official Build) (x86_64)
 * next v13.0.6
 * react v18.2.0
 * @ballerine/web-sdk v1.1.38

### Checklist
- [x] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [x] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas - (N/A)
- [-] I have made corresponding changes to the documentation - (N/A)
- [x] My changes generate no new warnings and errors
- [x] New and existing tests pass locally with my changes
