### PR TITLE
WIP - Add an example for the SDK using React and fix flow events

### DIFF
--- a/sdks/web-sdk/src/main.ts
+++ b/sdks/web-sdk/src/main.ts
@@ -22,19 +22,20 @@ export const flows: BallerineSDKFlows = {
       console.error('BallerineSDK: Could not find element with id', elementId);
     }
 
+    // Merge the passed in callbacks into the Svelte configuration store of the specified flow.
+    // Calling setFlowCallbacks after ConfigurationProvider results in stale state on instances of get(configuration).
+    if (config.callbacks) {
+      await setFlowCallbacks(flowName, config.callbacks);
+    }
+
     new ConfigurationProvider({
       target: document.getElementById(elementId) as HTMLElement,
       props: {
         flowName,
       },
     });
-
-    // Merge the passed in callbacks into the Svelte configuration store of the specified flow.
-    if (!config.callbacks) return;
-
-    await setFlowCallbacks(flowName, config.callbacks);
   },
-  openModal(flowName, config) {
+  async openModal(flowName, config) {
     const hostElement = document.querySelector('body');
     if (hostElement) {
       hostElement.innerHTML = `<div class="loader-container" id="blrn-loader">
@@ -43,6 +44,12 @@ export const flows: BallerineSDKFlows = {
     `;
     } else {
       console.error('BallerineSDK: Could not find element body');
+    }
+
+    // Merge the passed in callbacks into the Svelte configuration store of the specified flow.
+    // Calling setFlowCallbacks after ConfigurationProvider results in stale state on instances of get(configuration).
+    if (config.callbacks) {
+      await setFlowCallbacks(flowName, config.callbacks);
     }
 
     new ConfigurationProvider({

--- a/sdks/web-sdk/src/types/BallerineSDK.ts
+++ b/sdks/web-sdk/src/types/BallerineSDK.ts
@@ -119,7 +119,7 @@ export interface FlowsTranslations {
 export interface BallerineSDKFlows {
   init: (config: FlowsInitOptions) => Promise<void>;
   mount: (flowName: string, elementId: string, config: FlowsMountOptions) => Promise<void>;
-  openModal: (flowName: string, config: FlowsMountOptions) => void;
+  openModal: (flowName: string, config: FlowsMountOptions) => Promise<void>;
   setConfig: (config: FlowsInitOptions) => Promise<void>;
 }
 


### PR DESCRIPTION
### Description
Currently the examples directory does not have an example of how to use the web SDK using a package manager.
On the way flow events are fixed, calling setFlowCallbacks after ConfigurationProvider previously resulted in stale state on instances of get(configuration).

### Related issues

### Breaking changes

### How these changes were tested
 * In the examples directory locally using Chrome + Fedora desktop

### Examples and references

### Checklist
- [X] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [X] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and errors
- [X] New and existing tests pass locally with my changes
