### PR TITLE
Flow callbacks not merged into the Svelte store

### DIFF
--- a/sdks/web-sdk/src/dev.ts
+++ b/sdks/web-sdk/src/dev.ts
@@ -14,7 +14,7 @@ const ballerineInitConfig: FlowsInitOptions = {
         steps: [
           {
             name: Steps.Welcome,
-            id: Steps.Welcome
+            id: Steps.Welcome,
           },
           {
             name: Steps.DocumentSelection,
@@ -95,5 +95,5 @@ const ballerineInitConfig: FlowsInitOptions = {
 console.log(ballerineInitConfig);
 
 void flows.init(ballerineInitConfig).then(() => {
-  flows.openModal('my-kyc-flow', {});
+  void flows.openModal('my-kyc-flow', {});
 });

--- a/sdks/web-sdk/src/main.ts
+++ b/sdks/web-sdk/src/main.ts
@@ -6,7 +6,7 @@ import {
   updateTranslations,
 } from './lib/utils/configuration-manager';
 import { getConfigFromQueryParams } from './lib/utils/get-config-from-query-params';
-
+//
 export const flows: BallerineSDKFlows = {
   // Use the b_fid query param as the default flowName, fallback to the passed flowName arg.
   // Optional args/args with default values should probably be last.

--- a/sdks/web-sdk/src/main.ts
+++ b/sdks/web-sdk/src/main.ts
@@ -6,7 +6,7 @@ import {
   updateTranslations,
 } from './lib/utils/configuration-manager';
 import { getConfigFromQueryParams } from './lib/utils/get-config-from-query-params';
-//
+
 export const flows: BallerineSDKFlows = {
   // Use the b_fid query param as the default flowName, fallback to the passed flowName arg.
   // Optional args/args with default values should probably be last.
@@ -22,19 +22,20 @@ export const flows: BallerineSDKFlows = {
       console.error('BallerineSDK: Could not find element with id', elementId);
     }
 
+    // Merge the passed in callbacks into the Svelte configuration store of the specified flow.
+    // Calling setFlowCallbacks below ConfigurationProvider results in stale state for instances of get(configuration).
+    if (config.callbacks) {
+      await setFlowCallbacks(flowName, config.callbacks);
+    }
+
     new ConfigurationProvider({
       target: document.getElementById(elementId) as HTMLElement,
       props: {
         flowName,
       },
     });
-
-    // Merge the passed in callbacks into the Svelte configuration store of the specified flow.
-    if (!config.callbacks) return;
-
-    await setFlowCallbacks(flowName, config.callbacks);
   },
-  openModal(flowName, config) {
+  async openModal(flowName, config) {
     const hostElement = document.querySelector('body');
     if (hostElement) {
       hostElement.innerHTML = `<div class="loader-container" id="blrn-loader">
@@ -43,6 +44,12 @@ export const flows: BallerineSDKFlows = {
     `;
     } else {
       console.error('BallerineSDK: Could not find element body');
+    }
+
+    // Merge the passed in callbacks into the Svelte configuration store of the specified flow.
+    // Calling setFlowCallbacks below ConfigurationProvider results in stale state for instances of get(configuration).
+    if (config.callbacks) {
+      await setFlowCallbacks(flowName, config.callbacks);
     }
 
     new ConfigurationProvider({

--- a/sdks/web-sdk/src/types/BallerineSDK.ts
+++ b/sdks/web-sdk/src/types/BallerineSDK.ts
@@ -119,7 +119,7 @@ export interface FlowsTranslations {
 export interface BallerineSDKFlows {
   init: (config: FlowsInitOptions) => Promise<void>;
   mount: (flowName: string, elementId: string, config: FlowsMountOptions) => Promise<void>;
-  openModal: (flowName: string, config: FlowsMountOptions) => void;
+  openModal: (flowName: string, config: FlowsMountOptions) => Promise<void>;
   setConfig: (config: FlowsInitOptions) => Promise<void>;
 }
 


### PR DESCRIPTION
### Description
Prior to this PR callbacks such as onFlowNavigationUpdate did not fire. Moving setFlowCallbacks from below ConfigurationProvider to above it resolves the issue.

### Related issues

### Breaking changes

### How these changes were tested
 * Fedora desktop locally using Chrome
 
### Examples and references

### Checklist
- [X] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [X] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and errors
- [X] New and existing tests pass locally with my changes
