### PR TITLE
Added a method to reset svelte stores, now used in init

### DIFF
--- a/sdks/web-sdk/src/lib/contexts/app-state/stores.ts
+++ b/sdks/web-sdk/src/lib/contexts/app-state/stores.ts
@@ -22,7 +22,7 @@ export const documents = writable<IDocument[]>([]);
 // });
 
 //selected docs
-export const selectedDocumentInfo = writable<IDocumentInfo>();
+export const selectedDocumentInfo = writable<IDocumentInfo | undefined>();
 // let savedSelectedDocs = sessionStorage.getItem(STORAGE_DOCUMENT_INFO_KEY);
 // export const selectedDocumentInfo = writable<IDocumentInfo>(savedSelectedDocs ? JSON.parse(savedSelectedDocs) : "");
 // selectedDocumentInfo.subscribe(docInfo => {

--- a/sdks/web-sdk/src/lib/contexts/app-state/utils.ts
+++ b/sdks/web-sdk/src/lib/contexts/app-state/utils.ts
@@ -1,4 +1,14 @@
 import { EDocumentType, IDocument, IPageSide } from './types';
+import {
+  currentParams,
+  currentRoute,
+  currentStepId,
+  currentStepIdx,
+  documents,
+  selectedDocumentInfo,
+  selfieUri,
+} from './stores';
+import { Steps } from '../configuration';
 
 export const getDocImage = (
   type: EDocumentType,
@@ -10,4 +20,14 @@ export const getDocImage = (
   const page = doc.pages.find(p => p.side === pageSide) || doc.pages[0];
   if (!page) return '';
   return page.base64 as string;
+};
+
+export const resetAppState = () => {
+  selfieUri.set('');
+  documents.set([]);
+  selectedDocumentInfo.set(undefined);
+  currentStepIdx.set(0);
+  currentParams.set(null);
+  currentRoute.set(Steps.Welcome);
+  currentStepId.set(Steps.Welcome);
 };

--- a/sdks/web-sdk/src/main.ts
+++ b/sdks/web-sdk/src/main.ts
@@ -8,6 +8,7 @@ import {
 import { getConfigFromQueryParams } from './lib/utils/get-config-from-query-params';
 import { configuration } from './lib/contexts/configuration';
 import { configuration as defaultConfiguration } from './lib/configuration/configuration';
+import { resetAppState } from './lib/contexts/app-state/utils';
 //
 export const flows: BallerineSDKFlows = {
   // Use the b_fid query param as the default flowName, fallback to the passed flowName arg.
@@ -70,6 +71,8 @@ export const flows: BallerineSDKFlows = {
         config,
       );
 
+      // Always init with no state. This ensures using init to reset the flow returns to the first step with no data.
+      resetAppState();
       // Always init with no configuration. This handles multiple calls to init, i.e React re-renders.
       // Otherwise, the steps array could keep growing.
       configuration.set(defaultConfiguration);


### PR DESCRIPTION
### Description
In order to reset a flow its needed to call init and openModal/mount again. Doing so without resetting the Svelte stores would not navigate back to the first step and would break the flow.

### Related issues

### Breaking changes

### How these changes were tested
 * Fedora desktop locally in Chrome, omitted the loading and final steps from the flows config and tried calling init and openModal from the onFlowComplete callback with and without resetting the Svelte stores.

### Examples and references

### Checklist
- [X] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [X] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and errors
- [X] New and existing tests pass locally with my changes
