### PR TITLE
Disable CameraButton until video stream loads

### DIFF
--- a/sdks/web-sdk/src/lib/pages/DocumentPhoto.svelte
+++ b/sdks/web-sdk/src/lib/pages/DocumentPhoto.svelte
@@ -1,31 +1,31 @@
 <script lang="ts">
-  import CameraPhoto, { FACING_MODES } from 'jslib-html5-camera-photo';
-  import { T } from '../contexts/translation';
-  import { configuration } from '../contexts/configuration';
-  import { onDestroy, onMount } from 'svelte';
+  import CameraPhoto, { FACING_MODES } from "jslib-html5-camera-photo";
+  import { T } from "../contexts/translation";
+  import { configuration } from "../contexts/configuration";
+  import { onDestroy, onMount } from "svelte";
   import {
     CameraButton,
     IconButton,
     IconCloseButton,
+    Loader,
     Overlay,
     Paragraph,
-    VideoContainer,
-    Loader,
-  } from '../atoms';
-  import { Elements } from '../contexts/configuration/types';
-  import { EDocumentType, IDocument, appState } from '../contexts/app-state';
-  import { goToNextStep, goToPrevStep } from '../contexts/navigation';
-  import Title from '../atoms/Title/Title.svelte';
-  import { documents, currentStepId, selectedDocumentInfo } from '../contexts/app-state/stores';
-  import merge from 'deepmerge';
-  import { preloadNextStepByCurrent } from '../services/preload-service';
+    VideoContainer
+  } from "../atoms";
+  import { Elements } from "../contexts/configuration/types";
+  import { appState, EDocumentType, IDocument } from "../contexts/app-state";
+  import { goToNextStep, goToPrevStep } from "../contexts/navigation";
+  import Title from "../atoms/Title/Title.svelte";
+  import { currentStepId, documents, selectedDocumentInfo } from "../contexts/app-state/stores";
+  import merge from "deepmerge";
+  import { preloadNextStepByCurrent } from "../services/preload-service";
   import {
     EActionNames,
     EVerificationStatuses,
-    sendButtonClickEvent,
-  } from '../utils/event-service';
-  import { getLayoutStyles, getStepConfiguration, uiPack } from '../ui-packs';
-  import { createToggle } from '../hooks/createToggle/createToggle';
+    sendButtonClickEvent
+  } from "../utils/event-service";
+  import { getLayoutStyles, getStepConfiguration, uiPack } from "../ui-packs";
+  import { createToggle } from "../hooks/createToggle/createToggle";
 
   export let stepId;
 
@@ -36,7 +36,7 @@
   const step = getStepConfiguration($configuration, $uiPack, stepId);
   const style = getLayoutStyles($configuration, $uiPack, step);
 
-  const [isDisabled, , toggleOnIsDisabled] = createToggle();
+  const [isDisabled, , toggleOnIsDisabled, toggleOffIsDisabled] = createToggle(true);
 
   const documentOptionsConfiguration = merge(
     $uiPack.documentOptions,
@@ -68,6 +68,7 @@
       .then(cameraStream => {
         console.log('stream', cameraStream);
         stream = cameraStream;
+        toggleOffIsDisabled();
       })
       .catch(error => {
         console.log('error', error);

--- a/sdks/web-sdk/src/lib/pages/DocumentPhotoBack.svelte
+++ b/sdks/web-sdk/src/lib/pages/DocumentPhotoBack.svelte
@@ -1,25 +1,25 @@
 <script lang="ts">
-  import CameraPhoto, { FACING_MODES } from 'jslib-html5-camera-photo';
-  import { T } from '../contexts/translation';
-  import { configuration } from '../contexts/configuration';
-  import { onDestroy, onMount } from 'svelte';
+  import CameraPhoto, { FACING_MODES } from "jslib-html5-camera-photo";
+  import { T } from "../contexts/translation";
+  import { configuration } from "../contexts/configuration";
+  import { onDestroy, onMount } from "svelte";
   import {
     CameraButton,
     IconButton,
+    Loader,
     Overlay,
     Paragraph,
     Title,
-    VideoContainer,
-    Loader,
-  } from '../atoms';
-  import { Elements } from '../contexts/configuration/types';
-  import { goToNextStep, goToPrevStep } from '../contexts/navigation';
-  import { currentStepId, EDocumentType } from '../contexts/app-state';
-  import { documents, selectedDocumentInfo } from '../contexts/app-state/stores';
-  import { updateDocument } from '../utils/photo-utils';
-  import { createToggle } from '../hooks/createToggle/createToggle';
-  import { preloadNextStepByCurrent } from '../services/preload-service';
-  import { getLayoutStyles, getStepConfiguration, uiPack } from '../ui-packs';
+    VideoContainer
+  } from "../atoms";
+  import { Elements } from "../contexts/configuration/types";
+  import { goToNextStep, goToPrevStep } from "../contexts/navigation";
+  import { currentStepId, EDocumentType } from "../contexts/app-state";
+  import { documents, selectedDocumentInfo } from "../contexts/app-state/stores";
+  import { updateDocument } from "../utils/photo-utils";
+  import { createToggle } from "../hooks/createToggle/createToggle";
+  import { preloadNextStepByCurrent } from "../services/preload-service";
+  import { getLayoutStyles, getStepConfiguration, uiPack } from "../ui-packs";
 
   export let stepId;
 
@@ -29,7 +29,7 @@
   const step = getStepConfiguration($configuration, $uiPack, stepId);
   const style = getLayoutStyles($configuration, $uiPack, step);
 
-  const [isDisabled, , toggleOnIsDisabled] = createToggle();
+  const [isDisabled, , toggleOnIsDisabled, toggleOffIsDisabled] = createToggle(true);
 
   const documentType =
     ($uiPack.steps[$currentStepId].type as EDocumentType) ||
@@ -55,6 +55,7 @@
       .then(cameraStream => {
         console.log('stream', cameraStream);
         stream = cameraStream;
+        toggleOffIsDisabled();
       })
       .catch(error => {
         console.log('error', error);

--- a/sdks/web-sdk/src/lib/pages/Selfie.svelte
+++ b/sdks/web-sdk/src/lib/pages/Selfie.svelte
@@ -1,31 +1,31 @@
 <script lang="ts">
-  import CameraPhoto, { FACING_MODES } from 'jslib-html5-camera-photo';
-  import { T } from '../contexts/translation';
-  import { configuration } from '../contexts/configuration';
-  import { onDestroy, onMount } from 'svelte';
+  import CameraPhoto, { FACING_MODES } from "jslib-html5-camera-photo";
+  import { T } from "../contexts/translation";
+  import { configuration } from "../contexts/configuration";
+  import { onDestroy, onMount } from "svelte";
   import {
     CameraButton,
     IconButton,
     IconCloseButton,
+    Loader,
     Overlay,
     Paragraph,
-    VideoContainer,
-    Loader,
-  } from '../atoms';
-  import { Elements } from '../contexts/configuration/types';
-  import { goToNextStep, goToPrevStep } from '../contexts/navigation';
-  import { currentStepId, EDocumentType } from '../contexts/app-state';
-  import Title from '../atoms/Title/Title.svelte';
-  import { appState, selfieUri } from '../contexts/app-state/stores';
-  import { isMobile } from '../utils/is-mobile';
-  import { createToggle } from '../hooks/createToggle/createToggle';
-  import { preloadNextStepByCurrent } from '../services/preload-service';
+    VideoContainer
+  } from "../atoms";
+  import { Elements } from "../contexts/configuration/types";
+  import { goToNextStep, goToPrevStep } from "../contexts/navigation";
+  import { currentStepId, EDocumentType } from "../contexts/app-state";
+  import Title from "../atoms/Title/Title.svelte";
+  import { appState, selfieUri } from "../contexts/app-state/stores";
+  import { isMobile } from "../utils/is-mobile";
+  import { createToggle } from "../hooks/createToggle/createToggle";
+  import { preloadNextStepByCurrent } from "../services/preload-service";
   import {
     EActionNames,
     EVerificationStatuses,
-    sendButtonClickEvent,
-  } from '../utils/event-service';
-  import { getLayoutStyles, getStepConfiguration, uiPack } from '../ui-packs';
+    sendButtonClickEvent
+  } from "../utils/event-service";
+  import { getLayoutStyles, getStepConfiguration, uiPack } from "../ui-packs";
 
   let video: HTMLVideoElement;
   let cameraPhoto: CameraPhoto | undefined = undefined;
@@ -36,7 +36,7 @@
   const stepNamespace = step.namespace!;
   const style = getLayoutStyles($configuration, $uiPack, step);
 
-  const [isDisabled, , toggleOnIsDisabled] = createToggle();
+  const [isDisabled, , toggleOnIsDisabled, toggleOffIsDisabled] = createToggle(true);
 
   const facingMode = isMobile() ? FACING_MODES.USER : FACING_MODES.ENVIRONMENT;
   let stream: MediaStream;
@@ -52,6 +52,7 @@
       .then(cameraStream => {
         console.log('stream', cameraStream);
         stream = cameraStream;
+        toggleOffIsDisabled();
       })
       .catch(error => {
         console.log('error', error);


### PR DESCRIPTION
### Description
Avoids being able to take an empty picture/taking a picture while the video stream renders a loader.

### Related issues

### Breaking changes

### How these changes were tested
 * Fedora desktop locally in Chrome, went through the steps which have CameraButton

### Examples and references

### Checklist
- [X] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [X] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and errors
- [X] New and existing tests pass locally with my changes
