### PR TITLE
Merge openModal and mount, add ability to config a JWT in mount

### DIFF
--- a/examples/web-sdk/sdk-react/README.md
+++ b/examples/web-sdk/sdk-react/README.md
@@ -1,13 +1,29 @@
 ## Running SDK example
 
 1. Install dependencies:
-`pnpm install`
+   `pnpm install`
 
 2. Run example:
-`pnpm dev`
+   `pnpm dev`
 
 ### Modify configuration
 
 1. Duplicate and rename `src/configs/default-config.ts`
 2. On the duplicated file change default configuration
-3. Import the new configuration and pass it to `init` and `openModal` or `mount` functions
+
+- Skip 3. and 4. if you're not using our backend
+
+3. Generate a JWT
+
+```bash
+ curl --location --request POST 'https://api.ballerine.io/v2/create-enduser-token' \
+ --header 'Content-Type: application/json' \
+ --header 'Authorization: Api-Key [API_KEY]' \
+ --data-raw '{
+     "endUserId": "[ENDUSER_ID]",
+     "clientId": "[CLIENT_ID]"
+ }'
+```
+
+4. Add the JWT to the init config under `backendConfig.auth.auhtorizationHeader` as "Bearer [JWT]"
+5. Import the new configuration and pass it to `init` and `openModal` or `mount` functions

--- a/examples/web-sdk/sdk-react/README.md
+++ b/examples/web-sdk/sdk-react/README.md
@@ -26,4 +26,4 @@
 ```
 
 4. Add the JWT to the init config under `backendConfig.auth.auhtorizationHeader` as "Bearer [JWT]"
-5. Import the new configuration and pass it to `init` and `openModal` or `mount` functions
+5. Import the new configuration and pass it to `init` and `mount` functions

--- a/examples/web-sdk/sdk-react/pnpm-lock.yaml
+++ b/examples/web-sdk/sdk-react/pnpm-lock.yaml
@@ -4,7 +4,7 @@ importers:
 
   .:
     specifiers:
-      '@ballerine/web-sdk': file:./ballerine-web-sdk-1.3.0.tgz
+      '@ballerine/web-sdk': 1.3.0
       '@types/react': ^18.0.26
       '@types/react-dom': ^18.0.9
       '@vitejs/plugin-react': ^3.0.0
@@ -13,7 +13,7 @@ importers:
       typescript: ^4.9.3
       vite: 4.0.1
     dependencies:
-      '@ballerine/web-sdk': file:ballerine-web-sdk-1.3.0.tgz
+      '@ballerine/web-sdk': 1.3.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
@@ -250,6 +250,15 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
     dev: true
+
+  /@ballerine/web-sdk/1.3.0:
+    resolution: {integrity: sha512-o/xnHtvujuj7XbbdV8mN6L9PYHfnygyEy60vpj4uv2IuMTHfATF39fater3DK1wr3lEpSdxyr+381JAgTOt0JA==}
+    dependencies:
+      '@zerodevx/svelte-toast': 0.8.2
+      compressorjs: 1.1.1
+      dotenv: 16.0.3
+      jslib-html5-camera-photo: 3.3.4
+    dev: false
 
   /@esbuild/android-arm/0.16.9:
     resolution: {integrity: sha512-kW5ccqWHVOOTGUkkJbtfoImtqu3kA1PFkivM+9QPFSHphPfPBlBalX9eDRqPK+wHCqKhU48/78T791qPgC9e9A==}
@@ -880,14 +889,3 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
-
-  file:ballerine-web-sdk-1.3.0.tgz:
-    resolution: {integrity: sha512-7pdzGwwDyR6eVdnedmrTXo5XqVBwR1rc8ade1ZvNbhY3Mj65gCfYEdWi36cqW7Nb02MHCVk9P+Usozo8iyFyDQ==, tarball: file:ballerine-web-sdk-1.3.0.tgz}
-    name: '@ballerine/web-sdk'
-    version: 1.3.0
-    dependencies:
-      '@zerodevx/svelte-toast': 0.8.2
-      compressorjs: 1.1.1
-      dotenv: 16.0.3
-      jslib-html5-camera-photo: 3.3.4
-    dev: false

--- a/examples/web-sdk/sdk-react/pnpm-lock.yaml
+++ b/examples/web-sdk/sdk-react/pnpm-lock.yaml
@@ -4,7 +4,7 @@ importers:
 
   .:
     specifiers:
-      '@ballerine/web-sdk': 1.3.0
+      '@ballerine/web-sdk': file:./ballerine-web-sdk-1.3.0.tgz
       '@types/react': ^18.0.26
       '@types/react-dom': ^18.0.9
       '@vitejs/plugin-react': ^3.0.0
@@ -13,7 +13,7 @@ importers:
       typescript: ^4.9.3
       vite: 4.0.1
     dependencies:
-      '@ballerine/web-sdk': 1.3.0
+      '@ballerine/web-sdk': file:ballerine-web-sdk-1.3.0.tgz
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
@@ -250,15 +250,6 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
     dev: true
-
-  /@ballerine/web-sdk/1.3.0:
-    resolution: {integrity: sha512-o/xnHtvujuj7XbbdV8mN6L9PYHfnygyEy60vpj4uv2IuMTHfATF39fater3DK1wr3lEpSdxyr+381JAgTOt0JA==}
-    dependencies:
-      '@zerodevx/svelte-toast': 0.8.2
-      compressorjs: 1.1.1
-      dotenv: 16.0.3
-      jslib-html5-camera-photo: 3.3.4
-    dev: false
 
   /@esbuild/android-arm/0.16.9:
     resolution: {integrity: sha512-kW5ccqWHVOOTGUkkJbtfoImtqu3kA1PFkivM+9QPFSHphPfPBlBalX9eDRqPK+wHCqKhU48/78T791qPgC9e9A==}
@@ -889,3 +880,14 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
+
+  file:ballerine-web-sdk-1.3.0.tgz:
+    resolution: {integrity: sha512-7pdzGwwDyR6eVdnedmrTXo5XqVBwR1rc8ade1ZvNbhY3Mj65gCfYEdWi36cqW7Nb02MHCVk9P+Usozo8iyFyDQ==, tarball: file:ballerine-web-sdk-1.3.0.tgz}
+    name: '@ballerine/web-sdk'
+    version: 1.3.0
+    dependencies:
+      '@zerodevx/svelte-toast': 0.8.2
+      compressorjs: 1.1.1
+      dotenv: 16.0.3
+      jslib-html5-camera-photo: 3.3.4
+    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,8 @@ importers:
       svelte: ^3.39.0
       svelte-check: ^2.2.7
       svelte-preprocess: ^4.9.8
+      typedoc: ^0.23.23
+      typedoc-plugin-markdown: ^3.14.0
       typescript: ^4.5.4
       vite: 2.9.15
       vite-plugin-dts: ^1.6.6
@@ -237,6 +239,8 @@ importers:
       svelte: 3.55.0
       svelte-check: 2.10.2_nu2cmvfav5ouqeux3h72pagkka
       svelte-preprocess: 4.10.7_y2r476v6vd5yvrqoe6nl5px7pe
+      typedoc: 0.23.23_typescript@4.9.4
+      typedoc-plugin-markdown: 3.14.0_typedoc@0.23.23
       typescript: 4.9.4
       vite: 2.9.15
       vite-plugin-dts: 1.7.1_vite@2.9.15
@@ -9433,7 +9437,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -9580,7 +9584,6 @@ packages:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.17.4
-    dev: false
 
   /hard-rejection/2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -11841,6 +11844,10 @@ packages:
     dependencies:
       yallist: 4.0.0
 
+  /lunr/2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+    dev: true
+
   /lz-string/1.4.4:
     resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
     hasBin: true
@@ -11942,6 +11949,12 @@ packages:
     engines: {node: '>= 8.16.2'}
     hasBin: true
     dev: false
+
+  /marked/4.2.4:
+    resolution: {integrity: sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==}
+    engines: {node: '>= 12'}
+    hasBin: true
+    dev: true
 
   /match-sorter/6.3.1:
     resolution: {integrity: sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==}
@@ -12822,6 +12835,7 @@ packages:
     resolution: {integrity: sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==}
     dependencies:
       brace-expansion: 1.1.11
+    dev: true
 
   /minimatch/3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -15905,7 +15919,6 @@ packages:
       jsonc-parser: 3.2.0
       vscode-oniguruma: 1.7.0
       vscode-textmate: 6.0.0
-    dev: false
 
   /side-channel/1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -17078,6 +17091,29 @@ packages:
     dependencies:
       is-typedarray: 1.0.0
 
+  /typedoc-plugin-markdown/3.14.0_typedoc@0.23.23:
+    resolution: {integrity: sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==}
+    peerDependencies:
+      typedoc: '>=0.23.0'
+    dependencies:
+      handlebars: 4.7.7
+      typedoc: 0.23.23_typescript@4.9.4
+    dev: true
+
+  /typedoc/0.23.23_typescript@4.9.4:
+    resolution: {integrity: sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==}
+    engines: {node: '>= 14.14'}
+    hasBin: true
+    peerDependencies:
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x
+    dependencies:
+      lunr: 2.3.9
+      marked: 4.2.4
+      minimatch: 5.1.1
+      shiki: 0.11.1
+      typescript: 4.9.4
+    dev: true
+
   /typescript/4.8.4:
     resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
     engines: {node: '>=4.2.0'}
@@ -17094,7 +17130,6 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true
-    dev: false
     optional: true
 
   /unbox-primitive/1.0.2:
@@ -17710,11 +17745,9 @@ packages:
 
   /vscode-oniguruma/1.7.0:
     resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
-    dev: false
 
   /vscode-textmate/6.0.0:
     resolution: {integrity: sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==}
-    dev: false
 
   /vscode-uri/2.1.2:
     resolution: {integrity: sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==}
@@ -18092,7 +18125,6 @@ packages:
 
   /wordwrap/1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-    dev: false
 
   /workbox-background-sync/6.5.4:
     resolution: {integrity: sha512-0r4INQZMyPky/lj4Ou98qxcThrETucOde+7mRGJl13MPJugQNKeZQOdIJe/1AchOP23cTqHcN/YVpD6r8E6I8g==}

--- a/sdks/web-sdk/package.json
+++ b/sdks/web-sdk/package.json
@@ -80,6 +80,8 @@
     "svelte": "^3.39.0",
     "svelte-check": "^2.2.7",
     "svelte-preprocess": "^4.9.8",
+    "typedoc": "^0.23.23",
+    "typedoc-plugin-markdown": "^3.14.0",
     "typescript": "^4.5.4",
     "vite": "2.9.15",
     "vite-plugin-dts": "^1.6.6",

--- a/sdks/web-sdk/src/dev.ts
+++ b/sdks/web-sdk/src/dev.ts
@@ -95,5 +95,8 @@ const ballerineInitConfig: FlowsInitOptions = {
 console.log(ballerineInitConfig);
 
 void flows.init(ballerineInitConfig).then(() => {
-  void flows.openModal('my-kyc-flow', {});
+  void flows.mount({
+    flowName: 'my-kyc-flow',
+    useModal: true,
+  });
 });

--- a/sdks/web-sdk/src/main.ts
+++ b/sdks/web-sdk/src/main.ts
@@ -1,6 +1,7 @@
 import ConfigurationProvider from './ConfigurationProvider.svelte';
 import type { BallerineSDKFlows, FlowsInitOptions } from './types/BallerineSDK';
 import {
+  setAuthorizationHeaderJwt,
   setFlowCallbacks,
   updateConfiguration,
   updateTranslations,
@@ -38,8 +39,9 @@ export const flows: BallerineSDKFlows = {
       },
     });
   },
-  async openModal(flowName, config) {
+  async openModal(flowName, { callbacks, jwt }) {
     const hostElement = document.querySelector('body');
+
     if (hostElement) {
       hostElement.innerHTML = `<div class="loader-container" id="blrn-loader">
       <div class="loader"></div>
@@ -51,8 +53,13 @@ export const flows: BallerineSDKFlows = {
 
     // Merge the passed in callbacks into the Svelte configuration store of the specified flow.
     // Calling setFlowCallbacks below ConfigurationProvider results in stale state for instances of get(configuration).
-    if (config.callbacks) {
-      await setFlowCallbacks(flowName, config.callbacks);
+    if (callbacks) {
+      await setFlowCallbacks(flowName, callbacks);
+    }
+
+    // Skipped if not using JWT auth.
+    if (jwt) {
+      setAuthorizationHeaderJwt(jwt);
     }
 
     new ConfigurationProvider({

--- a/sdks/web-sdk/src/main.ts
+++ b/sdks/web-sdk/src/main.ts
@@ -9,7 +9,7 @@ import { getConfigFromQueryParams } from './lib/utils/get-config-from-query-para
 import { configuration } from './lib/contexts/configuration';
 import { configuration as defaultConfiguration } from './lib/configuration/configuration';
 import { resetAppState } from './lib/contexts/app-state/utils';
-//
+
 export const flows: BallerineSDKFlows = {
   // Use the b_fid query param as the default flowName, fallback to the passed flowName arg.
   // Optional args/args with default values should probably be last.

--- a/sdks/web-sdk/src/main.ts
+++ b/sdks/web-sdk/src/main.ts
@@ -15,32 +15,16 @@ export const flows: BallerineSDKFlows = {
   // Use the b_fid query param as the default flowName, fallback to the passed flowName arg.
   // Optional args/args with default values should probably be last.
   // Async due to setFlowCallbacks using updateConfiguration, which is async.
-  async mount(flowName = getConfigFromQueryParams().flowName, elementId, config) {
-    const hostElement = document.getElementById(elementId);
-    if (hostElement) {
-      hostElement.innerHTML = `<div class="loader-container" id="blrn-loader">
-      <div class="loader"></div>
-    </div>
-    `;
-    } else {
-      console.error('BallerineSDK: Could not find element with id', elementId);
-    }
-
-    // Merge the passed in callbacks into the Svelte configuration store of the specified flow.
-    // Calling setFlowCallbacks below ConfigurationProvider results in stale state for instances of get(configuration).
-    if (config.callbacks) {
-      await setFlowCallbacks(flowName, config.callbacks);
-    }
-
-    new ConfigurationProvider({
-      target: document.getElementById(elementId) as HTMLElement,
-      props: {
-        flowName,
-      },
-    });
-  },
-  async openModal(flowName, { callbacks, jwt }) {
-    const hostElement = document.querySelector('body');
+  async mount({
+    flowName = getConfigFromQueryParams().flowName,
+    callbacks,
+    jwt,
+    useModal = false,
+    elementId = '',
+  }) {
+    const hostElement = useModal
+      ? document.querySelector('body')
+      : document.getElementById(elementId);
 
     if (hostElement) {
       hostElement.innerHTML = `<div class="loader-container" id="blrn-loader">
@@ -48,7 +32,9 @@ export const flows: BallerineSDKFlows = {
     </div>
     `;
     } else {
-      console.error('BallerineSDK: Could not find element body');
+      const message = useModal ? 'body' : `with id ${elementId}`;
+
+      console.error(`BallerineSDK: Could not find element ${message}`);
     }
 
     // Merge the passed in callbacks into the Svelte configuration store of the specified flow.
@@ -66,7 +52,7 @@ export const flows: BallerineSDKFlows = {
       target: hostElement as HTMLElement,
       props: {
         flowName,
-        useModal: true,
+        useModal,
       },
     });
   },

--- a/sdks/web-sdk/src/types/BallerineSDK.ts
+++ b/sdks/web-sdk/src/types/BallerineSDK.ts
@@ -108,7 +108,7 @@ export interface FlowsInitOptions {
 interface FlowsMountOptions {
   callbacks?: FlowsEventsConfig;
   /**
-   * Requires {@link FlowsInitOptions.backendConfig.auth} method to be set as 'jwt'
+   * @description A JWT token to use in the Authorization header. Requires {@link FlowsInitOptions.backendConfig.auth} method to be set as 'jwt'
    */
   jwt?: string;
 }

--- a/sdks/web-sdk/src/types/BallerineSDK.ts
+++ b/sdks/web-sdk/src/types/BallerineSDK.ts
@@ -107,6 +107,10 @@ export interface FlowsInitOptions {
 
 interface FlowsMountOptions {
   callbacks?: FlowsEventsConfig;
+  /**
+   * Requires {@link FlowsInitOptions.backendConfig.auth} method to be set as 'jwt'
+   */
+  jwt?: string;
 }
 
 type FlowsModalOptions = FlowsMountOptions;

--- a/sdks/web-sdk/src/types/BallerineSDK.ts
+++ b/sdks/web-sdk/src/types/BallerineSDK.ts
@@ -105,16 +105,24 @@ export interface FlowsInitOptions {
   translations?: FlowsTranslations;
 }
 
-interface FlowsMountOptions {
+interface IFlowsMountOptions {
+  flowName: string;
+  /**
+   * @description A boolean to decide where to mount the flow - if true, the flow will be mounted in the body element.
+   *
+   * @default false
+   */
+  useModal?: boolean;
+  /**
+   * @description Required if useModal is not used or is set to false. The string id attribute of the element to mount the flow in.
+   */
+  elementId?: string;
   callbacks?: FlowsEventsConfig;
   /**
    * @description A JWT token to use in the Authorization header. Requires {@link FlowsInitOptions.backendConfig.auth} method to be set as 'jwt'
    */
   jwt?: string;
 }
-
-type FlowsModalOptions = FlowsMountOptions;
-
 export interface FlowsTranslations {
   overrides?: Record<string, AnyRecord>;
   remoteUrl?: string;
@@ -122,8 +130,7 @@ export interface FlowsTranslations {
 
 export interface BallerineSDKFlows {
   init: (config: FlowsInitOptions) => Promise<void>;
-  mount: (flowName: string, elementId: string, config: FlowsMountOptions) => Promise<void>;
-  openModal: (flowName: string, config: FlowsMountOptions) => Promise<void>;
+  mount: (config: IFlowsMountOptions) => Promise<void>;
   setConfig: (config: FlowsInitOptions) => Promise<void>;
 }
 

--- a/sdks/web-sdk/src/types/BallerineSDK.ts
+++ b/sdks/web-sdk/src/types/BallerineSDK.ts
@@ -106,6 +106,9 @@ export interface FlowsInitOptions {
 }
 
 export interface IFlowsMountOptions {
+  /**
+   * @description The object key of the flow to be rendered.
+   */
   flowName: string;
   /**
    * @description A boolean to decide where to mount the flow - if true, the flow will be mounted in the body element.

--- a/sdks/web-sdk/src/types/BallerineSDK.ts
+++ b/sdks/web-sdk/src/types/BallerineSDK.ts
@@ -105,7 +105,7 @@ export interface FlowsInitOptions {
   translations?: FlowsTranslations;
 }
 
-interface IFlowsMountOptions {
+export interface IFlowsMountOptions {
   flowName: string;
   /**
    * @description A boolean to decide where to mount the flow - if true, the flow will be mounted in the body element.

--- a/websites/docs/src/components/SidebarContent/SidebarContent.astro
+++ b/websites/docs/src/components/SidebarContent/SidebarContent.astro
@@ -47,7 +47,7 @@ const lang = getLanguageFromURL(Astro.url.pathname);
                 href={
                   external
                     ? link
-                    : `${Astro.site?.pathname}${lang}/${type}/${link}/`
+                    : `${Astro.site?.pathname}${lang}/${type}/${link}`
                 }
                 aria-current={`${
                   currentPageMatch.endsWith(link) ? `page` : `false`

--- a/websites/docs/src/pages/en/api/sdk/ballerine-sdk-flows.md
+++ b/websites/docs/src/pages/en/api/sdk/ballerine-sdk-flows.md
@@ -14,88 +14,43 @@ layout: ../../../../layouts/MainLayout.astro
 
 ▸ (`config`): `Promise`<`void`\>
 
-**`Description`**
-
-Initializes the SDK
-
 ##### Parameters
 
-| Name     | Type                                        | Description                             |
-| :------- | :------------------------------------------ | :-------------------------------------- |
-| `config` | [`FlowsInitOptions`](../flows-init-options) | The initialization configuration object |
+| Name     | Type                                        |
+| :------- | :------------------------------------------ |
+| `config` | [`FlowsInitOptions`](../flows-init-options) |
 
 ##### Returns
 
 `Promise`<`void`\>
 
-Promise<void>
-
 #### Defined in
 
-[BallerineSDK.ts:138](https://github.com/ballerine-io/ballerine/blob/ec0b014/sdks/web-sdk/src/types/BallerineSDK.ts#L138)
+[BallerineSDK.ts:132](https://github.com/ballerine-io/ballerine/blob/aacaaa6/sdks/web-sdk/src/types/BallerineSDK.ts#L132)
 
 ---
 
 ### mount
 
-• **mount**: (`flowName`: `string`, `elementId`: `string`, `config`: [`FlowsMountOptions`](../flows-mount-options)) => `Promise`<`void`\>
+• **mount**: (`config`: [`IFlowsMountOptions`](../flows-mount-options)) => `Promise`<`void`\>
 
 #### Type declaration
 
-▸ (`flowName`, `elementId`, `config`): `Promise`<`void`\>
-
-**`Description`**
-
-Mounts the flow in the specified element
+▸ (`config`): `Promise`<`void`\>
 
 ##### Parameters
 
-| Name        | Type                                          | Description                                 |
-| :---------- | :-------------------------------------------- | :------------------------------------------ |
-| `flowName`  | `string`                                      | The object key of the flow to be rendered   |
-| `elementId` | `string`                                      | The id of the element to render the flow in |
-| `config`    | [`FlowsMountOptions`](../flows-mount-options) | The mount configuration object              |
+| Name     | Type                                           |
+| :------- | :--------------------------------------------- |
+| `config` | [`IFlowsMountOptions`](../flows-mount-options) |
 
 ##### Returns
 
 `Promise`<`void`\>
 
-Promise<void>
-
 #### Defined in
 
-[BallerineSDK.ts:146](https://github.com/ballerine-io/ballerine/blob/ec0b014/sdks/web-sdk/src/types/BallerineSDK.ts#L146)
-
----
-
-### openModal
-
-• **openModal**: (`flowName`: `string`, `config`: [`FlowsMountOptions`](../flows-mount-options)) => `void`
-
-#### Type declaration
-
-▸ (`flowName`, `config`): `void`
-
-**`Description`**
-
-Opens the flow in a modal
-
-##### Parameters
-
-| Name       | Type                                          | Description                               |
-| :--------- | :-------------------------------------------- | :---------------------------------------- |
-| `flowName` | `string`                                      | The object key of the flow to be rendered |
-| `config`   | [`FlowsMountOptions`](../flows-mount-options) | The mount configuration object            |
-
-##### Returns
-
-`void`
-
-Promise<void>
-
-#### Defined in
-
-[BallerineSDK.ts:153](https://github.com/ballerine-io/ballerine/blob/ec0b014/sdks/web-sdk/src/types/BallerineSDK.ts#L153)
+[BallerineSDK.ts:133](https://github.com/ballerine-io/ballerine/blob/aacaaa6/sdks/web-sdk/src/types/BallerineSDK.ts#L133)
 
 ---
 
@@ -107,22 +62,16 @@ Promise<void>
 
 ▸ (`config`): `Promise`<`void`\>
 
-**`Description`**
-
-Initializes the SDK
-
 ##### Parameters
 
-| Name     | Type                                        | Description                             |
-| :------- | :------------------------------------------ | :-------------------------------------- |
-| `config` | [`FlowsInitOptions`](../flows-init-options) | The initialization configuration object |
+| Name     | Type                                        |
+| :------- | :------------------------------------------ |
+| `config` | [`FlowsInitOptions`](../flows-init-options) |
 
 ##### Returns
 
 `Promise`<`void`\>
 
-Promise<void>
-
 #### Defined in
 
-[BallerineSDK.ts:159](https://github.com/ballerine-io/ballerine/blob/ec0b014/sdks/web-sdk/src/types/BallerineSDK.ts#L159)
+[BallerineSDK.ts:134](https://github.com/ballerine-io/ballerine/blob/aacaaa6/sdks/web-sdk/src/types/BallerineSDK.ts#L134)

--- a/websites/docs/src/pages/en/api/sdk/flows-mount-options.md
+++ b/websites/docs/src/pages/en/api/sdk/flows-mount-options.md
@@ -34,6 +34,10 @@ Required if useModal is not used or is set to false. The string id attribute of 
 
 • **flowName**: `string`
 
+**`Description`**
+
+The object key of the flow to be rendered.
+
 #### Defined in
 
 [BallerineSDK.ts:109](https://github.com/ballerine-io/ballerine/blob/aacaaa6/sdks/web-sdk/src/types/BallerineSDK.ts#L109)

--- a/websites/docs/src/pages/en/api/sdk/flows-mount-options.md
+++ b/websites/docs/src/pages/en/api/sdk/flows-mount-options.md
@@ -8,8 +8,64 @@ layout: ../../../../layouts/MainLayout.astro
 
 ### callbacks
 
-• `Optional` **callbacks**: [`FlowsEventsConfig`](../flows-events-config)
+• `Optional` **callbacks**: [`FlowsEventsConfig`](./flows-events-config)
 
 #### Defined in
 
-[BallerineSDK.ts:122](https://github.com/ballerine-io/ballerine/blob/ec0b014/sdks/web-sdk/src/types/BallerineSDK.ts#L122)
+[BallerineSDK.ts:120](https://github.com/ballerine-io/ballerine/blob/aacaaa6/sdks/web-sdk/src/types/BallerineSDK.ts#L120)
+
+---
+
+### elementId
+
+• `Optional` **elementId**: `string`
+
+**`Description`**
+
+Required if useModal is not used or is set to false. The string id attribute of the element to mount the flow in.
+
+#### Defined in
+
+[BallerineSDK.ts:119](https://github.com/ballerine-io/ballerine/blob/aacaaa6/sdks/web-sdk/src/types/BallerineSDK.ts#L119)
+
+---
+
+### flowName
+
+• **flowName**: `string`
+
+#### Defined in
+
+[BallerineSDK.ts:109](https://github.com/ballerine-io/ballerine/blob/aacaaa6/sdks/web-sdk/src/types/BallerineSDK.ts#L109)
+
+---
+
+### jwt
+
+• `Optional` **jwt**: `string`
+
+**`Description`**
+
+A JWT token to use in the Authorization header. Requires FlowsInitOptions.backendConfig.auth method to be set as 'jwt'
+
+#### Defined in
+
+[BallerineSDK.ts:124](https://github.com/ballerine-io/ballerine/blob/aacaaa6/sdks/web-sdk/src/types/BallerineSDK.ts#L124)
+
+---
+
+### useModal
+
+• `Optional` **useModal**: `boolean`
+
+**`Description`**
+
+A boolean to decide where to mount the flow - if true, the flow will be mounted in the body element.
+
+**`Default`**
+
+false
+
+#### Defined in
+
+[BallerineSDK.ts:115](https://github.com/ballerine-io/ballerine/blob/aacaaa6/sdks/web-sdk/src/types/BallerineSDK.ts#L115)


### PR DESCRIPTION
### Description
Before this change the `openModal` and `mount` methods used to be almost identical, now differences are decided based on a `useModal` boolean. In addition to this change,  `mount` now accepts an optional JWT property to pass into the authorization header config.

### Related issues

### Breaking changes
 * `openModal` is removed, `mount` now accepts an options object instead of arguments to avoid passing too many arguments after the addition of `useModal` or having to pass all arguments just to get to the `useModal` argument.

### How these changes were tested
 * Fedora desktop, locally in Chrome using the web-sdk's dev web server.

### Examples and references

### Checklist
- [X] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [X] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings and errors
- [X] New and existing tests pass locally with my changes
