### PR TITLE
feat(web-sdk): transparent pixel based analytics

### DIFF
--- a/sdks/web-sdk/src/App.svelte
+++ b/sdks/web-sdk/src/App.svelte
@@ -8,6 +8,7 @@
   import { t } from './lib/contexts/translation/hooks';
   import { setFlowName } from './lib/contexts/flows';
   import { uiPack } from './lib/ui-packs';
+  import MetricsPixel from './lib/atoms/MetricsPixel/MetricsPixel.svelte';
 
   subscribe();
   initConnectionCheck(t);
@@ -54,6 +55,7 @@
       },
     }}
   />
+  <MetricsPixel/>
 </main>
 
 <style>

--- a/sdks/web-sdk/src/dev.ts
+++ b/sdks/web-sdk/src/dev.ts
@@ -91,6 +91,9 @@ const ballerineInitConfig: FlowsInitOptions = {
       },
     },
   },
+  metricsConfig: {
+    enabled: false
+  }
 };
 console.log(ballerineInitConfig);
 

--- a/sdks/web-sdk/src/lib/atoms/MetricsPixel/MetricsPixel.svelte
+++ b/sdks/web-sdk/src/lib/atoms/MetricsPixel/MetricsPixel.svelte
@@ -1,0 +1,31 @@
+
+<script lang="ts">
+  import { configuration } from '../../../lib/contexts/configuration';
+  import { getFlowConfig } from '../../contexts/flows/hooks';
+
+  let baseURL = import.meta.env.VITE_METRICS_BASE_URL
+  export let enabled = $configuration.metricsConfig.enabled
+  let flow = getFlowConfig($configuration);
+
+  const meta = {
+    flowName: flow.name,
+    flowSteps: flow.stepsOrder
+  };
+
+  let payload = window.btoa(JSON.stringify(meta));  
+  console.log('is metrics enabled', enabled)
+  export let endpoint = `${baseURL}/v2/metrics/png?meta=${payload}`
+  
+</script>
+
+{#if enabled}
+<img alt="ballerine metrics" src={endpoint}/>
+{/if}
+
+<style>
+  img {
+    height: 1px;
+    width: 1px;
+    border-style: none;
+  }
+</style>

--- a/sdks/web-sdk/src/lib/configuration/configuration.ts
+++ b/sdks/web-sdk/src/lib/configuration/configuration.ts
@@ -48,4 +48,7 @@ export const configuration: IAppConfiguration = {
       useFinalQueryParams: true,
     },
   },
+  metricsConfig: {
+    enabled: true
+  }
 };

--- a/sdks/web-sdk/src/lib/contexts/configuration/types.ts
+++ b/sdks/web-sdk/src/lib/contexts/configuration/types.ts
@@ -6,6 +6,8 @@ import { IFlow } from '../flows';
 import { EndUserInfo, FlowsBackendConfig } from '../../../types/BallerineSDK';
 import { EDocumentType, EDocumentKind } from '../app-state';
 import { ICSSProperties } from '../../services/css-manager';
+import { MetricsConfig} from '../../../types/BallerineSDK'
+
 
 export enum Steps {
   Welcome = 'welcome',
@@ -162,9 +164,11 @@ export interface IAppConfiguration extends Partial<IAppConfigurationUI> {
   };
   flows: { [key: string]: IFlow };
   defaultLanguage: 'en' | 'es';
+  metricsConfig: MetricsConfig;
 }
 
 export interface ConfigSettings {
   cameraSettings: CaptureConfigOption;
   selfieCameraSettings: CaptureConfigOption;
 }
+

--- a/sdks/web-sdk/src/types/BallerineSDK.ts
+++ b/sdks/web-sdk/src/types/BallerineSDK.ts
@@ -64,6 +64,10 @@ interface FlowsUIConfig {
   settings?: ConfigSettings;
 }
 
+export interface MetricsConfig {
+  enabled?: boolean;
+}
+
 export interface FlowsEventsConfig {
   onFlowComplete?: (payload: IFlowCompletePayload) => void;
   onFlowExit?: (payload: IFlowExitPayload) => void;
@@ -100,6 +104,7 @@ export interface FlowsBackendConfig {
 export interface FlowsInitOptions {
   version?: string;
   uiConfig?: Partial<FlowsUIConfig>;
+  metricsConfig?: Partial<MetricsConfig>;
   endUserInfo: EndUserInfo;
   backendConfig?: FlowsBackendConfig;
   translations?: FlowsTranslations;


### PR DESCRIPTION
### Description
Transparent pixel based analytics

***Note:*** You must update `.env` and `.env.production` with proper for `VITE_METRICS_BASE_URL` values (i.e. VITE_METRICS_BASE_URL=http://localhost:3001)