### PR TITLE
Added missing passport translations

### DIFF
--- a/sdks/web-sdk/src/lib/configuration/translation.json
+++ b/sdks/web-sdk/src/lib/configuration/translation.json
@@ -91,6 +91,10 @@
       }
     },
     "document-photo-back": {
+      "passport": {
+        "title": "Passport back side",
+        "description": "Place the back side of your Passport card inside the frame and \ntake a picture. \nMake sure it is not cut or has any glare."
+      },
       "id_card": {
         "title": "ID Card back side",
         "description": "Place the back side of your ID Card inside the frame and \ntake a picture. \nMake sure it is not cut or has any glare."


### PR DESCRIPTION
### Description
Prior to this PR translations were missing for the KYB passport step for document photo back

### Related issues

### Breaking changes

### How these changes were tested
 * On Fedora desktop, in Chrome locally translations that were previously missing are now present.

### Examples and references

### Checklist
- [x] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [x] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and errors
- [x] New and existing tests pass locally with my changes
