### PR TITLE
Fix search for businesses

### DIFF
--- a/apps/backoffice-v2/src/components/pages/Individuals/hooks/useIndividuals/useIndividuals.tsx
+++ b/apps/backoffice-v2/src/components/pages/Individuals/hooks/useIndividuals/useIndividuals.tsx
@@ -13,6 +13,7 @@ import { individualRoute } from 'components/pages/Individual/Individual.route';
 import { useEndUsersWithWorkflowsQuery } from '../../../../../lib/react-query/queries/useEndUsersWithWorkflowsQuery/useEndUsersWithWorkflowsQuery';
 import { useUsersQuery } from '../../../../../lib/react-query/queries/useUsersQuery/useUsersQuery';
 import { useSort } from 'hooks/useSort/useSort';
+import { useFilterEntity } from 'hooks/useFilterEntity/useFilterEntity';
 
 export const useIndividuals = () => {
   const matches = useMatches();
@@ -22,10 +23,18 @@ export const useIndividuals = () => {
   const routeId: TRouteId = isIndividuals ? individualsRoute.id : individualRoute.id;
   const { data: users } = useUsersQuery();
   const { data: subjects, isLoading } = useEndUsersWithWorkflowsQuery(users);
+  const entity = useFilterEntity();
+  const individualsSearchOptions = ['firstName', 'lastName', 'email', 'phone'];
+  const businessesSearchOptions = [
+    'companyName',
+    'registrationNumber',
+    'legalForm',
+    'countryOfIncorporation',
+  ];
   const { searched, onSearch, search } = useSearch({
     routeId,
     data: subjects,
-    searchBy: ['firstName', 'lastName', 'email', 'phone'],
+    searchBy: entity === 'individuals' ? individualsSearchOptions : businessesSearchOptions,
   });
   const { sorted, onSortBy, onSortDir } = useSort({
     routeId,


### PR DESCRIPTION
Businesses may now search by companyName, registrationNumber, legalForm, or countryOfIncorporation. Was previously using individuals properties like firstName which did not work.

### Description
Elaborate on the subject, motivation, and context.

### Related issues
 * Provide a link to each related issue.

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings and errors
- [] New and existing tests pass locally with my changes
