### PR TITLE
Fix disk file uploads

### DIFF
--- a/services/workflows-service/src/storage/get-file-storage-manager.ts
+++ b/services/workflows-service/src/storage/get-file-storage-manager.ts
@@ -1,13 +1,15 @@
 import { diskStorage } from 'multer';
 import { getFileName } from '@/storage/get-file-name';
 import multerS3 from 'multer-s3';
-import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import * as tmp from 'tmp';
 import * as fs from 'fs';
 
 import { Readable } from 'stream';
 import { AwsS3FileConfig } from '@/providers/file/file-provider/aws-s3-file.config';
 import { TLocalFile } from '@/storage/types';
+import path from 'path';
+import os from 'os';
 
 export const manageFileByProvider = (processEnv: NodeJS.ProcessEnv) => {
   if (AwsS3FileConfig.isConfigured(processEnv)) {
@@ -17,8 +19,10 @@ export const manageFileByProvider = (processEnv: NodeJS.ProcessEnv) => {
       bucket: AwsS3FileConfig.fetchBucketName(processEnv) as string,
     });
   } else {
+    const root = path.parse(os.homedir()).root;
+
     return diskStorage({
-      destination: './upload',
+      destination: `${root}/tmp`,
       filename: getFileName,
     });
   }

--- a/services/workflows-service/src/storage/storage.controller.external.ts
+++ b/services/workflows-service/src/storage/storage.controller.external.ts
@@ -12,7 +12,6 @@ import { downloadFileFromS3, manageFileByProvider } from '@/storage/get-file-sto
 import { AwsS3FileConfig } from '@/providers/file/file-provider/aws-s3-file.config';
 import * as os from 'os';
 import * as path from 'path';
-import console from 'console';
 
 // Temporarily identical to StorageControllerInternal
 @swagger.ApiTags('Storage')
@@ -46,7 +45,7 @@ export class StorageControllerExternal {
   async uploadFile(@UploadedFile() file: Partial<Express.MulterS3.File>) {
     const id = await this.service.createFileLink({
       uri: file.location || String(file.path),
-      fileNameOnDisk: String(file.location),
+      fileNameOnDisk: String(file.path),
       fileNameInBucket: file.key,
       // Probably wrong. Would require adding a relationship (Prisma) and using connect.
       userId: '',


### PR DESCRIPTION
### Description
Prior to this change the `fileNameOnDisk` property used in `uploadFile` in the external storage controller was different from the internal property, and the upload destrination was mistakenly `./upload` which was different than the path used to get the file by its id.

### Related issues
 * Provide a link to each related issue.

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [x] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [x] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and errors
- [x] New and existing tests pass locally with my changes
