### PR TITLE
Remove redundant auth redirects

### DIFF
--- a/apps/backoffice-v2/src/domains/auth/components/AuthenticatedLayout/AuthenticatedLayout.layout.tsx
+++ b/apps/backoffice-v2/src/domains/auth/components/AuthenticatedLayout/AuthenticatedLayout.layout.tsx
@@ -1,10 +1,10 @@
 import { Header } from '../../../../common/components/organisms/Header';
 import { FunctionComponentWithChildren } from '../../../../common/types';
-import { useAuthenticatedLayout } from './hooks/useAuthenticatedLayout/useAuthenticatedLayout';
 import { useSelectEntityFilterOnMount } from '../../../entities/hooks/useSelectEntityFilterOnMount/useSelectEntityFilterOnMount';
 
 export const AuthenticatedLayout: FunctionComponentWithChildren = ({ children }) => {
-  useAuthenticatedLayout();
+  // Should only be uncommented once `useAuthRedirects` is no longer in use in `AuthProvider`
+  // useAuthenticatedLayout();
   useSelectEntityFilterOnMount();
 
   return (

--- a/apps/backoffice-v2/src/domains/auth/components/UnauthenticatedLayout/UnauthenticatedLayout.layout.tsx
+++ b/apps/backoffice-v2/src/domains/auth/components/UnauthenticatedLayout/UnauthenticatedLayout.layout.tsx
@@ -1,8 +1,8 @@
-import { useUnauthenticatedLayout } from './hooks/useUnauthenticatedLayout/useUnauthenticatedLayout';
 import { FunctionComponentWithChildren } from '../../../../common/types';
 
 export const UnauthenticatedLayout: FunctionComponentWithChildren = ({ children }) => {
-  useUnauthenticatedLayout();
+  // Should only be uncommented once `useAuthRedirects` is no longer in use in `AuthProvider`
+  // useUnauthenticatedLayout();
 
   return (
     <main className={`h-full`}>

--- a/apps/backoffice-v2/src/domains/auth/hooks/mutations/useSignOutMutation/useSignOutMutation.tsx
+++ b/apps/backoffice-v2/src/domains/auth/hooks/mutations/useSignOutMutation/useSignOutMutation.tsx
@@ -18,7 +18,9 @@ export const useSignOutMutation = () => {
       queryClient.cancelQueries();
     },
     onSuccess: (data, { callbackUrl, redirect }) => {
-      queryClient.setQueryData(authenticatedUser.queryKey, undefined);
+      queryClient.setQueryData(authenticatedUser.queryKey, {
+        user: undefined,
+      });
 
       if (!callbackUrl || !redirect) return;
 

--- a/apps/backoffice-v2/src/lib/react-query/query-client.ts
+++ b/apps/backoffice-v2/src/lib/react-query/query-client.ts
@@ -32,7 +32,9 @@ export const queryClient = new QueryClient({
         const authenticatedUser = authQueryKeys.authenticatedUser();
 
         void queryClient.cancelQueries();
-        queryClient.setQueryData(authenticatedUser.queryKey, undefined);
+        queryClient.setQueryData(authenticatedUser.queryKey, {
+          user: undefined,
+        });
         await queryClient.invalidateQueries(authenticatedUser.queryKey);
       }
 


### PR DESCRIPTION
### Description
The hooks `useAuthenticatedLayout` and `useUnauthenticatedLayout` were supposed to be used instead of `useAuthRedirects` and not in addition to. This PR lets `useAuthRedirects` handle the auth redirects logic.

### Checklist
- [x] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [x] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and errors
- [x] New and existing tests pass locally with my changes
