### PR TITLE
workflow core rules cap

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,29 +1,34 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Attach",
-            "port": 9229,
-            "request": "attach",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "type": "node"
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Launch Program",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "program": "${workspaceFolder}/services/workflows-service/src/workflow/workflow-runtime-data.repository.ts",
-            "outFiles": [
-                "${workspaceFolder}/**/*.js"
-            ]
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/services/workflows-service/src/workflow/workflow-runtime-data.repository.ts",
+      "outFiles": ["${workspaceFolder}/**/*.js"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Current Test File",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
+      "args": ["run", "${relativeFile}"],
+      "smartStep": true,
+      "console": "integratedTerminal"
+    }
+  ]
 }

--- a/packages/workflow-core/package.json
+++ b/packages/workflow-core/package.json
@@ -22,6 +22,7 @@
     "watch": "tsc -w",
     "dev": "concurrently --kill-others \"pnpm build -w\" \"pnpm watch\"",
     "test": "vitest run",
+    "test:watch": "vitest",
     "test:unit": "vitest run"
   },
   "engines": {

--- a/packages/workflow-core/src/lib/workflow-runner.test.ts
+++ b/packages/workflow-core/src/lib/workflow-runner.test.ts
@@ -334,14 +334,16 @@ describe('workflow-runner', () => {
   });
 });
 
-describe('Workflows with conditions', () => {
+describe.only('Workflows with conditions', () => {
   it('allows to define conditions', async () => {
     // create workflow with conditions
-    const workflow = new WorkflowRunner({
+    const workflow = createEventCollectingWorkflow({
       workflowContext: {
-        external_request_example: {
-          data: {
-            name_fuzziness_score: 0.85, // or whatever value you want to assign
+        machineContext: {
+          external_request_example: {
+            data: {
+              name_fuzziness_score: 0.85, // or whatever value you want to assign
+            },
           },
         },
       },
@@ -357,12 +359,9 @@ describe('Workflows with conditions', () => {
                     type: 'json-logic',
                     options: {
                       rule: {
-                        '>': [
-                          { var: 'context.external_request_example.data.name_fuzziness_score' },
-                          0.5,
-                        ],
+                        '>': [{ var: 'external_request_example.data.name_fuzziness_score' }, 0.5],
                       },
-                      onFailed: { manualReviewReason: 'name not matching ... ' },
+                      assignOnFailure: { manualReviewReason: 'name not matching ... ' },
                     },
                   },
                 },
@@ -380,7 +379,8 @@ describe('Workflows with conditions', () => {
       },
     });
     await workflow.sendEvent({ type: 'EVENT' });
-    console.log(workflow);
-    expect(true).toEqual(true);
+    console.log(workflow.events);
+    expect(workflow.events[0].state).toEqual('final');
+    // expect(workflow.#__context).toContain({ manualReviewReason: 'name not matching ... ' });
   });
 });

--- a/packages/workflow-core/src/lib/workflow-runner.test.ts
+++ b/packages/workflow-core/src/lib/workflow-runner.test.ts
@@ -335,52 +335,84 @@ describe('workflow-runner', () => {
 });
 
 describe.only('Workflows with conditions', () => {
-  it('allows to define conditions', async () => {
-    // create workflow with conditions
-    const workflow = createEventCollectingWorkflow({
-      workflowContext: {
-        machineContext: {
-          external_request_example: {
-            data: {
-              name_fuzziness_score: 0.85, // or whatever value you want to assign
-            },
+  const createCondMachine = score => ({
+    workflowContext: {
+      machineContext: {
+        external_request_example: {
+          data: {
+            name_fuzziness_score: 0.85, // or whatever value you want to assign
           },
         },
       },
-      definition: {
-        initial: 'initial',
-        states: {
-          initial: {
-            on: {
-              EVENT: [
-                {
-                  target: 'final',
-                  cond: {
-                    type: 'json-logic',
-                    options: {
-                      rule: {
-                        '>': [{ var: 'external_request_example.data.name_fuzziness_score' }, 0.5],
-                      },
-                      assignOnFailure: { manualReviewReason: 'name not matching ... ' },
+    },
+    definition: {
+      initial: 'initial',
+      states: {
+        initial: {
+          on: {
+            EVENT: [
+              {
+                target: 'final',
+                cond: {
+                  type: 'json-logic',
+                  options: {
+                    rule: {
+                      '>': [{ var: 'external_request_example.data.name_fuzziness_score' }, score],
                     },
+                    assignOnFailure: { manualReviewReason: 'name not matching ... ' },
                   },
                 },
-                { target: 'middle' },
-              ],
-            },
-          },
-          middle: {
-            on: { EVENT: { target: 'final', cond: 'isTrue' } },
-          },
-          final: {
-            type: 'final',
+              },
+            ],
           },
         },
+        middle: {
+          on: { EVENT2: { target: 'final', cond: 'isTrue' } },
+        },
+        final: {
+          type: 'final',
+        },
       },
-    });
+    },
+  });
+  it('should not proceed with transition if json logic condition falsy', async () => {
+    const workflow = createEventCollectingWorkflow(createCondMachine(0.9));
     await workflow.sendEvent({ type: 'EVENT' });
-    console.log(workflow.events);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(workflow.events[0].state).toEqual('initial');
+  });
+  it('should proceed with transition if json logic condition truthy', async () => {
+    const workflowArgs = createCondMachine(0.5);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    const workflow = createEventCollectingWorkflow(workflowArgs);
+    await workflow.sendEvent({ type: 'EVENT' });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect(workflow.events[0].state).toEqual('final');
+    // expect(workflow.#__context).toContain({ manualReviewReason: 'name not matching ... ' });
+  });
+  it('should proceed with transition if json logic condition truthy, and default transition is set', async () => {
+    const workflowArgs = createCondMachine(0.5);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    workflowArgs.definition.states.initial.on.EVENT.push({ target: 'middle' });
+    const workflow = createEventCollectingWorkflow(workflowArgs);
+    await workflow.sendEvent({ type: 'EVENT' });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(workflow.events[0].state).toEqual('final');
+    // expect(workflow.#__context).toContain({ manualReviewReason: 'name not matching ... ' });
+  });
+  it('should not proceed with transition if json logic condition truthy, but transition to a default state THIS TEST SHOULD BE REVISIONED', async () => {
+    const workflowArgs = createCondMachine(0.9);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    workflowArgs.definition.states.initial.on.EVENT.push({ target: 'middle' });
+    console.log(JSON.stringify(workflowArgs.definition, null, 2));
+
+    const workflow = createEventCollectingWorkflow(workflowArgs);
+    await workflow.sendEvent({ type: 'EVENT' });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(workflow.events[0].state).toEqual('initial');
     // expect(workflow.#__context).toContain({ manualReviewReason: 'name not matching ... ' });
   });
 });

--- a/packages/workflow-core/src/lib/workflow-runner.ts
+++ b/packages/workflow-core/src/lib/workflow-runner.ts
@@ -163,10 +163,11 @@ export class WorkflowRunner {
     };
 
     const guards: MachineOptions<any, any>['guards'] = {
-      'json-rule': (ctx, { payload }, { cond }) => {
-        const data = { ...ctx, ...payload };
+      'json-logic': (ctx, event, metadata) => {
+        const data = { ...ctx, ...event.payload };
         return jsonLogic.apply(
-          cond.name, // Rule
+          // @ts-expect-error
+          metadata.cond.options.rule, // Rule
           data, // Data
         );
       },

--- a/packages/workflow-core/src/lib/workflow-runner.ts
+++ b/packages/workflow-core/src/lib/workflow-runner.ts
@@ -165,11 +165,22 @@ export class WorkflowRunner {
     const guards: MachineOptions<any, any>['guards'] = {
       'json-logic': (ctx, event, metadata) => {
         const data = { ...ctx, ...event.payload };
-        return jsonLogic.apply(
-          // @ts-expect-error
-          metadata.cond.options.rule, // Rule
+        // @ts-expect-error
+        const options = metadata.cond.options;
+        console.log(`running json logic rule`, data, metadata.cond);
+
+        const ruleResult = jsonLogic.apply(
+          options.rule, // Rule
           data, // Data
         );
+        if (!ruleResult && options.assignOnFailure) {
+          this.#__context = {
+            ...this.#__context,
+            ...options.assignOnFailure,
+          };
+        }
+        console.log(`json logic rule result`, ruleResult);
+        return ruleResult;
       },
     };
 

--- a/packages/workflow-core/src/lib/workflow-runner.ts
+++ b/packages/workflow-core/src/lib/workflow-runner.ts
@@ -2,7 +2,7 @@
 import { uniqueArray } from '@ballerine/common';
 import * as jsonLogic from 'json-logic-js';
 import type { ActionFunction, MachineOptions, StateMachine } from 'xstate';
-import { createMachine, interpret } from 'xstate';
+import { createMachine, interpret, assign } from 'xstate';
 import { HttpError } from './errors';
 import type {
   ObjectValues,
@@ -22,6 +22,7 @@ export class WorkflowRunner {
   #__callback: ((event: WorkflowEvent) => void) | null = null;
   #__extensions: WorkflowExtensions;
   #__debugMode: boolean;
+  events: any;
 
   public get workflow() {
     return this.#__workflow;
@@ -174,10 +175,13 @@ export class WorkflowRunner {
           data, // Data
         );
         if (!ruleResult && options.assignOnFailure) {
-          this.#__context = {
-            ...this.#__context,
-            ...options.assignOnFailure,
-          };
+          this.#__callback?.({
+            type: 'RULE_EVALUATION_FAILURE',
+            state: this.#__currentState,
+            payload: {
+              ...options,
+            },
+          });
         }
         console.log(`json logic rule result`, ruleResult);
         return ruleResult;


### PR DESCRIPTION
- Backoffice case filter (#202)
- Change individual view to render tasks as blocks (#213)
- style(prettier): applied format changes
- Workflows service + backoffice authentication (#222)
- feat(common): policies schema
- feat(wf-service): webhooks initial (#264)
- WIP - KYB example workflow (#254)
- update db schema
- refactor(headless-example): now rendering start x flow button text based on example type (kyc/kyb)
- update db schema
- feat(useindividual): added reject functionality for a task
- build dev image
- feat(backoffice-v2): added unversioned changes
- build dev image
- build dev image
- build dev image
- build dev image
- build dev image
- refactor(backoffice-v2): disabled buttons that have no functionality
- build dev image
- build dev image
- feat(prisma.schema): added indexes for filtering and ordering ( scoping )
- fix(kyc-example): app sends always fetch business even if running kyc (#272)
- Add`resolvedAt` to `WorkflowRuntimeData` model (#290)
- Create enum `WorkflowRuntimeDataStatus` (#291)
- Case filters - server-side (#292)
- Filter cases by assignee (#299)
- Businesses sorting fix (#269)
- Feature/remove unnecessary indexes (#277)
- Blokh/feat/assign case (#307)
- fix: filter by assignee
- style: auto-fix lint issues
- Add API key (#308)
- Backoffice form blocks (#312)
- API versioning (#305)
- add context scehma to seed, started api endpoint (#295)
- fix(bad merge): fix bad merge
- CI FIX
- Blokh/feat/implment-s-3-filemanager (#284)
- CI FIX
- Replace SecretService and ConfigService with @t3-oss/env-core (#293)
- refactor(*): added v1 into the url of places refrencing the workflows service api
- wf-service: update seed
- feat(documents): add documents properties schema
- fix(types): global types
- wf-service: update seed
- Add Sentry to the workflows service (#329)
- fix(pr comments): fix condition
- wf-service: update seed
- wf-service: update seed
- wf-service: update seed
- feat(documents): add documents properties schema (#331)
- wf-service: update seed
- wf-service: update seed
- fix dev
- Backoffice UI fixes (#335)
- WIP - Build forms via server data (#324)
- Backoffice decision details section (#339)
- fix debug (sentry regression)
- Blokh/feat/persist file document and refactor worfklow service (#336)
- Yairp/feat/call webhooks (#314)
- fix(files-provider): lint fixes
- ci fix
- ci fix
- (CI): adding pnpm install
- (CI): skip jwt test (not in use)
- (CI): remove sentry upload sourcemaps from images publish action
- (CI): skip jwt test (not in use)
- (CI): skip jwt test (not in use)
- WIP - Validate editable fields on server side (#340)
- fix(assginee): fix assginee after update workflow runtome addtioans (#349)
- fixed entity validation issue
- Approve now resets rejectionReason + now actions are disabled again when not assigned (#350)
- fixed status not present pn webhook sending attempts
- Revision state (#356)
- Update active workflows (#353)
- Fix default filters not checked on mount (#361)
- fix(backoffice-v2): fixed sort by createdAt
- Remove entity type filter (#365)
- Yairp/feat/call webhooks part2 (#346)
- (hotfix): add httpmodule, null check for decision
- (hotfix): add httpmodule, null check for decision
- refactor(backoffice-v2 sign-in): replaced the old sign in form with shadcn's (#366)
- fix(backoffice-v2): businesses can now search based on companyName instead of firstName (#367)
- Blokh/fix/file service exceptions (#363)
- feat(update-context): update workflow rt status if all tasks completed (#369)
- fix(backoffice-v2): improved behavior on selecting an initial entity, especially after sign in (#370)
- Fix backoffice toast messages (#374)
- feat: add space to the save button (#377)
- fix: improve document form spacing
- add backoffice markdown
- fix(backoffice-v2): no longer conditionally rendering filters - now updating initial values (#372)
- add backoffice markdown
- Backoffice workflow status filter with default (#378)
- Backoffice minor changes (#381)
- Fix workflow upsert BL (#385)
- feat: disable action buttons of documents with decision (#387)
- Blokh/fix/local file path storage (#388)
- Update back-office.md (#391)
- add backoffice markdown
- add backoffice markdown
- duplicate images fix (#399)
- Blokh/feat/show assign UI  (#390)
- Hide case action buttons configuration (#400)
- feat(backoffice): add favicon
- feat(package.json): now using wait-on so the backoffice doesn't go up before the server (#401)
- added backoffice + api example script to package.json
- feat(backoffice-v2): added optimistic updates to a workflow's context - handles form editing (#407)
- fix sending files data back to the server
- feat(added deafault node version): added default node version (#410)
- Replace form component and move cell components (#414)
- fix: ocr toast
- fix(backoffice-v2): added missing key prop to form fields
- fix(backoffice-v2): fixed task block disabled actions
- Fix Sentry source maps upload (#375)
- Blokh/feat/seed files (#411)
- Add Windows to the CI (#416)
- refactor(backoffice-v2): change agent email in the bottom left to first name + last name (#430)
- feat(backoffice-v2): added a root error component with a link back to the home page (#431)
- Populate individuals context and context documents in seed (#434)
- Fix disk file uploads (#438)
- Alert on webhook failure (#433)
- Add an endpoint to receive a workflow's context (#432)
- Session guard by default (#440)
- Blokh/feat/run docker as dumbinit (#442)
- Blokh/feat/run docker as dumbinit (#443)
- fix: updated access to protected endpoints without user to return 401 instead of 403
- fix session cookies (#439)
- Assignment polling (#445)
- Print backoffice validation and env validation errors in the terminal (#436)
- fix: stop using deprecated faker methods
- CD: Run migrations (#454)
- cors settings
- Upgrade node verion from 16 to 18.12.1 in CI (#472)
- Add logs (#452)
- Backoffice structure (#415)
- Blokh/feat/create user endpoint (#457)
- fix: remove cookie from headers log
- refactor(backoffice-v2): removed animation from entity's name in actions component (#477)
- cors settings
- Fix backoffice breaking on refresh and on sign in / sign out (#481)
- fix(backoffice-v2): wip fixing sign out re-renders (#489)
- Adding document properties schemas (#459)
- making registrationNumber optional
- **Test in deployment first** Backoffice - migrate `@tanstack/react-router`  to `react-router-dom` (#486)
- Dynamic webhook config (#501)
- feat(generated assignee-asigned-guard): assign endpoint (#451)
- Blokh/feat/backoffice image (#505)
- added logo url
- fix image logo by updating name to  VITE_IMAGE_LOGO_URL
- refactor(db-schema): remove enduser unneccesary fields (#508)
- fixed document props update
- backoffice: fixed addtional info on entity
- add ajv keywords
- update pnpm lock file
- fix pdf view in backoffice
- fix(backoffice-v2): fixed height for image viewer - addresses how pdfs are displayed
- Blokh/feat/default case filter assignee (#480)
- update doc type (#515)
- updated common reference
- update common versions
- backoffice signin logo regression fix
- added test env ci
- Cases pagination, sorting, filtering, and search (#516)
- feat: create workflows websocket service (#499)
- feat(vite.config.ts): added sourcemaps
- update common
- Blokh/fix/refactor update category (#517)
- Blokh/feat/test infra (#500)
- feat: added handling of prisma validation errors to workflow controller (#511)
- add kyb w/ external request (#541)
- workflow rules draft 1

### Description
Elaborate on the subject, motivation, and context.

### Related issues
 * Provide a link to each related issue.

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings and errors
- [] New and existing tests pass locally with my changes
