### PR TITLE
fix: fixed websocket-service path in init script

### DIFF
--- a/scripts/init.js
+++ b/scripts/init.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 
 const rootDir = path.join(__dirname, '..');
 const workflowServiceRoot = path.join(rootDir, 'services/workflows-service');
-const workflowWebsocketServiceRoot = path.join(rootDir, 'services/workflows-websocket-service');
+const workflowWebsocketServiceRoot = path.join(rootDir, 'services/websocket-service');
 const backofficeRoot = path.join(rootDir, 'apps/backoffice-v2');
 
 const ensureEnvFileIsPresent = projectPath => {


### PR DESCRIPTION
### Description
Updated path to `websocket-service` from `workflows-websocket-service` to make `init.js` script work.

### Related issues
 * Provide a link to each related issue.

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings and errors
- [] New and existing tests pass locally with my changes
