### PR TITLE
fix: list filters state persists in localstorage

### DIFF
--- a/apps/backoffice-v2/src/common/components/organisms/Header/Header.Navbar.tsx
+++ b/apps/backoffice-v2/src/common/components/organisms/Header/Header.Navbar.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useEffect } from 'react';
 import { NavItem } from './Header.NavItem';
 import { useFiltersQuery } from '../../../../domains/filters/hooks/queries/useFiltersQuery/useFiltersQuery';
 import { ctw } from '../../../utils/ctw/ctw';
@@ -16,7 +16,7 @@ import { useSelectEntityFilterOnMount } from '../../../../domains/entities/hooks
  */
 export const Navbar: FunctionComponent = () => {
   const { data: filters } = useFiltersQuery();
-  const [searchParams] = useSearchParamsByEntity();
+  const [searchParams, setSearchParams] = useSearchParamsByEntity();
   const navItems = [
     // {
     //   text: 'Home',
@@ -25,6 +25,18 @@ export const Navbar: FunctionComponent = () => {
     //   key: 'nav-item-home',
     // },
   ] satisfies TRoutes;
+
+  useEffect(() => {
+    const caseFilters = localStorage.getItem('cases-filter');
+
+    if (caseFilters) {
+      const caseFilter = JSON.parse(caseFilters);
+      setSearchParams({
+        filter: caseFilter,
+        page: 1,
+      });
+    }
+  }, [searchParams]);
 
   useSelectEntityFilterOnMount();
 

--- a/apps/backoffice-v2/src/common/utils/set-localstorage/set-localstorage.ts
+++ b/apps/backoffice-v2/src/common/utils/set-localstorage/set-localstorage.ts
@@ -1,0 +1,3 @@
+export const setLocalStorage = (key: string, value: any) => {
+  localStorage.setItem(key, JSON.stringify(value));
+};

--- a/apps/backoffice-v2/src/pages/Entities/components/Cases/Cases.tsx
+++ b/apps/backoffice-v2/src/pages/Entities/components/Cases/Cases.tsx
@@ -7,7 +7,6 @@ import { Checkbox } from '../../../../common/components/atoms/Checkbox/Checkbox'
 import { useCases } from './hooks/useCases/useCases';
 import { SkeletonItem } from './Cases.SkeletonItem';
 import { TIndividual } from '../../../../domains/individuals/types';
-
 /**
  * @description A vertical sidebar for the cases list, with search, filter, and sort.
  * Uses dot notation for its API (i.e. Cases.List), where the root component acts as a container.
@@ -66,7 +65,7 @@ export const Cases: FunctionComponent<ICasesProps> & ICasesChildren = ({
           </div>
         </div>
         <div className={`flex items-center justify-between`}>
-          <div className="dropdown-hover dropdown dropdown-bottom z-[60]">
+          <div className="dropdown-hover dropdown-bottom dropdown z-[60]">
             <button
               className={`btn-ghost btn-sm btn h-[2.125rem] gap-2 border-neutral/10 text-xs focus-visible:outline-primary theme-dark:border-neutral/50`}
               tabIndex={0}
@@ -115,7 +114,7 @@ export const Cases: FunctionComponent<ICasesProps> & ICasesChildren = ({
           >
             <div className={`input-group flex items-center`}>
               <button
-                className={`btn-ghost btn-sm btn-square btn !rounded-md focus-visible:border-none focus-visible:bg-neutral/10 focus-visible:outline-none focus-visible:ring-0 focus-visible:theme-dark:bg-neutral`}
+                className={`btn-ghost btn-square btn-sm btn !rounded-md focus-visible:border-none focus-visible:bg-neutral/10 focus-visible:outline-none focus-visible:ring-0 focus-visible:theme-dark:bg-neutral`}
                 onClick={onSortDirToggle}
                 ref={sortRef}
               >

--- a/apps/backoffice-v2/src/pages/Entities/hooks/useEntities/useEntities.tsx
+++ b/apps/backoffice-v2/src/pages/Entities/hooks/useEntities/useEntities.tsx
@@ -5,6 +5,7 @@ import { useSelectEntityOnMount } from '../../../../domains/entities/hooks/useSe
 import { useWorkflowsQuery } from '../../../../domains/workflows/hooks/queries/useWorkflowsQuery/useWorkflowsQuery';
 import { useSearchParamsByEntity } from '../../../../common/hooks/useSearchParamsByEntity/useSearchParamsByEntity';
 import { useEntityType } from '../../../../common/hooks/useEntityType/useEntityType';
+import { setLocalStorage } from '../../../../common/utils/set-localstorage/set-localstorage';
 
 export const useEntities = () => {
   const [{ filterId, filter, sortBy, sortDir, page, pageSize }, setSearchParams] =
@@ -53,6 +54,12 @@ export const useEntities = () => {
             [key]: values,
           },
           page: 1,
+        });
+
+        localStorage.removeItem('cases-filter');
+        setLocalStorage('cases-filter', {
+          ...filter,
+          [key]: values,
         });
       };
     },


### PR DESCRIPTION
### Description
When moving between views (from the navbar) the inner list filters reset to default.

### Related issues
 * https://github.com/ballerine-io/ballerine/issues/512

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings and errors
- [] New and existing tests pass locally with my changes
