### PR TITLE
Backoffice EditableDetails date fields

### DIFF
--- a/apps/backoffice-v2/src/common/utils/is-valid-date/is-valid-date.ts
+++ b/apps/backoffice-v2/src/common/utils/is-valid-date/is-valid-date.ts
@@ -5,7 +5,14 @@ import { z } from 'zod';
  * @param value
  * @param strict - If false, will return true for strings that match the format YYYY-MM-DD.
  */
-export const isValidDate = (value: unknown, strict = true): value is string => {
+export const isValidDate = (
+  value: unknown,
+  {
+    strict = true,
+  }: {
+    strict?: boolean;
+  },
+): value is string => {
   if (typeof value !== 'string') return false;
 
   if (!strict && /\d{4}-\d{2}-\d{2}/.test(value)) return true;

--- a/apps/backoffice-v2/src/common/utils/is-valid-date/is-valid-date.ts
+++ b/apps/backoffice-v2/src/common/utils/is-valid-date/is-valid-date.ts
@@ -3,19 +3,19 @@ import { z } from 'zod';
 /**
  * @description Checks if a passed value is a datetime string.
  * @param value
- * @param strict - If false, will return true for strings that match the format YYYY-MM-DD.
+ * @param isStrict - If false, will return true for strings that match the format YYYY-MM-DD.
  */
 export const isValidDate = (
   value: unknown,
   {
-    strict = true,
+    isStrict = true,
   }: {
-    strict?: boolean;
-  },
+    isStrict?: boolean;
+  } = {},
 ): value is string => {
   if (typeof value !== 'string') return false;
 
-  if (!strict && /\d{4}-\d{2}-\d{2}/.test(value)) return true;
+  if (!isStrict && /\d{4}-\d{2}-\d{2}/.test(value)) return true;
 
   return z.string().datetime().safeParse(value).success;
 };

--- a/apps/backoffice-v2/src/pages/Entity/components/EditableDetails/EditableDetails.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/components/EditableDetails/EditableDetails.tsx
@@ -123,7 +123,7 @@ export const EditableDetails: FunctionComponent<IEditableDetails> = ({
         return 'text';
       }
 
-      if (isValidDate(value, false) || isValidIsoDate(value) || type === 'date') {
+      if (isValidDate(value, { isStrict: false }) || isValidIsoDate(value) || type === 'date') {
         return 'date';
       }
 

--- a/apps/backoffice-v2/src/pages/Entity/components/EditableDetails/EditableDetails.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/components/EditableDetails/EditableDetails.tsx
@@ -25,6 +25,8 @@ import { isNullish, isObject } from '@ballerine/common';
 import { isValidUrl } from '../../../../common/utils/is-valid-url';
 import { JsonDialog } from '../../../../common/components/molecules/JsonDialog/JsonDialog';
 import { FileJson2 } from 'lucide-react';
+import { isValidDate } from '../../../../common/utils/is-valid-date';
+import { isValidIsoDate } from '../../../../common/utils/is-valid-iso-date/is-valid-iso-date';
 
 const useInitialCategorySetValue = ({ form, data }) => {
   useEffect(() => {
@@ -156,6 +158,21 @@ export const EditableDetails: FunctionComponent<IEditableDetails> = ({
                       !Array.isArray(value),
                     ].every(Boolean);
                     const isSelect = isInput && !!dropdownOptions;
+                    const inputType = (() => {
+                      if (format) {
+                        return format;
+                      }
+
+                      if (type === 'string') {
+                        return 'text';
+                      }
+
+                      if (isValidDate(value, false) || isValidIsoDate(value) || type === 'date') {
+                        return 'date';
+                      }
+
+                      return type;
+                    })();
 
                     return (
                       <FormItem>
@@ -224,7 +241,7 @@ export const EditableDetails: FunctionComponent<IEditableDetails> = ({
                         {isInput && !isSelect && (
                           <FormControl>
                             <Input
-                              type={!format ? (type === 'string' ? 'text' : type) : format}
+                              type={inputType}
                               disabled={!isEditable}
                               className={ctw(
                                 `p-1 disabled:cursor-auto disabled:border-none disabled:bg-transparent disabled:opacity-100`,

--- a/apps/backoffice-v2/src/pages/Entity/components/EditableDetails/EditableDetails.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/components/EditableDetails/EditableDetails.tsx
@@ -171,6 +171,10 @@ export const EditableDetails: FunctionComponent<IEditableDetails> = ({
                         return 'date';
                       }
 
+                      if (!type) {
+                        return 'text';
+                      }
+
                       return type;
                     })();
 

--- a/apps/backoffice-v2/src/pages/Entity/components/EditableDetails/EditableDetails.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/components/EditableDetails/EditableDetails.tsx
@@ -5,7 +5,7 @@ import { toStartCase } from '../../../../common/utils/to-start-case/to-start-cas
 import { camelCaseToSpace } from '../../../../common/utils/camel-case-to-space/camel-case-to-space';
 import { Input } from '../../../../common/components/atoms/Input/Input';
 import { Button, buttonVariants } from '../../../../common/components/atoms/Button/Button';
-import React, { ChangeEvent, FunctionComponent, useEffect, useState } from 'react';
+import React, { ChangeEvent, FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { AnyRecord } from '../../../../common/types';
 import { IEditableDetails } from './interfaces';
 import { useUpdateWorkflowByIdMutation } from '../../../../domains/workflows/hooks/mutations/useUpdateWorkflowByIdMutation/useUpdateWorkflowByIdMutation';
@@ -105,6 +105,36 @@ export const EditableDetails: FunctionComponent<IEditableDetails> = ({
     });
   };
   const isDecisionComponent = title === 'Decision';
+  const getInputType = useCallback(
+    ({
+      format,
+      type,
+      value,
+    }: {
+      format: string | undefined;
+      type: string | undefined;
+      value: unknown;
+    }) => {
+      if (format) {
+        return format;
+      }
+
+      if (type === 'string') {
+        return 'text';
+      }
+
+      if (isValidDate(value, false) || isValidIsoDate(value) || type === 'date') {
+        return 'date';
+      }
+
+      if (!type) {
+        return 'text';
+      }
+
+      return type;
+    },
+    [],
+  );
 
   useWatchDropdownOptions({ form, data, setFormData });
   useInitialCategorySetValue({
@@ -158,25 +188,11 @@ export const EditableDetails: FunctionComponent<IEditableDetails> = ({
                       !Array.isArray(value),
                     ].every(Boolean);
                     const isSelect = isInput && !!dropdownOptions;
-                    const inputType = (() => {
-                      if (format) {
-                        return format;
-                      }
-
-                      if (type === 'string') {
-                        return 'text';
-                      }
-
-                      if (isValidDate(value, false) || isValidIsoDate(value) || type === 'date') {
-                        return 'date';
-                      }
-
-                      if (!type) {
-                        return 'text';
-                      }
-
-                      return type;
-                    })();
+                    const inputType = getInputType({
+                      format,
+                      type,
+                      value,
+                    });
 
                     return (
                       <FormItem>

--- a/apps/backoffice-v2/src/pages/Entity/components/KycBlock/hooks/useKycBlock/useKycBlock.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/components/KycBlock/hooks/useKycBlock/useKycBlock.tsx
@@ -38,8 +38,6 @@ export const useKycBlock = ({
         {
           title: 'Verified With',
           value: capitalize(childWorkflow?.context?.pluginsOutput?.kyc_session[key]?.vendor),
-          type: 'text',
-          format: 'text',
           pattern: '',
           isEditable: false,
           dropdownOptions: undefined,
@@ -49,8 +47,6 @@ export const useKycBlock = ({
           value:
             childWorkflow?.context?.pluginsOutput?.kyc_session[key]?.result?.decision?.decision
               ?.decision,
-          type: 'text',
-          format: 'text',
           pattern: '',
           isEditable: false,
           dropdownOptions: undefined,
@@ -63,8 +59,6 @@ export const useKycBlock = ({
                 key
               ]?.decision?.decision?.riskLabels?.join(', ')
             : 'none',
-          type: 'text',
-          format: 'text',
           pattern: '',
           isEditable: false,
           dropdownOptions: undefined,
@@ -72,8 +66,6 @@ export const useKycBlock = ({
         {
           title: 'Full report',
           value: childWorkflow?.context?.pluginsOutput?.kyc_session[key],
-          type: 'text',
-          format: 'text',
           pattern: '',
           isEditable: false,
           dropdownOptions: undefined,
@@ -102,8 +94,6 @@ export const useKycBlock = ({
           })?.map(([title, value]) => ({
             title,
             value,
-            type: 'text',
-            format: 'text',
             pattern: '',
             isEditable: false,
             dropdownOptions: undefined,
@@ -114,8 +104,6 @@ export const useKycBlock = ({
   const details = Object.entries(childWorkflow?.context?.entity?.data).map(([title, value]) => ({
     title,
     value,
-    type: 'text',
-    format: 'text',
     pattern: '',
     isEditable: true,
     dropdownOptions: undefined,

--- a/apps/backoffice-v2/src/pages/Entity/components/NestedComponent/handle-nested-value.ts
+++ b/apps/backoffice-v2/src/pages/Entity/components/NestedComponent/handle-nested-value.ts
@@ -13,7 +13,9 @@ export const handleNestedValue = ({
   showUndefined: boolean;
   showNull: boolean;
 }) => {
-  if (isValidDate(value, false) || isValidIsoDate(value)) return formatDate(dayjs(value).toDate());
+  if (isValidDate(value, { isStrict: false }) || isValidIsoDate(value)) {
+    return formatDate(dayjs(value).toDate());
+  }
   if (value === undefined && showUndefined) return 'undefined';
   if (value === null && showNull) return 'null';
   if (!isNullish(value)) return value?.toString();


### PR DESCRIPTION
### Description
`EditableDetails` now has fallback for when no `type` or `format` are passed with values, date fields are now also checked against validation if a value does not have `type` of `date` or `format` of `date`.

### Related issues
 * Provide a link to each related issue.

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [x] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [x] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and errors
- [x] New and existing tests pass locally with my changes
