### PR TITLE
Fix task decision validation error

### DIFF
--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -722,6 +722,10 @@ export class WorkflowService {
       documents: workflow?.context?.documents?.map(
         (document: DefaultContextSchema['documents'][number]) => ({
           ...document,
+          decision: {
+            ...document?.decision,
+            status: document?.decision?.status === null ? undefined : document?.decision?.status,
+          },
           type:
             document?.type === 'unknown' && document?.decision?.status === 'approved'
               ? undefined


### PR DESCRIPTION
### Description
Closes #1208. Prior to this change trying to approve a task or ask for re-upload would fail due to invalid decision status.

