### PR TITLE
Fix pnpm-lockfile pointing at wrong branchlint version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
     devDependencies:
       '@branchlint/cli':
         specifier: ^1.0.5
-        version: 1.1.0
+        version: 1.0.5
       '@branchlint/default-config':
         specifier: ^1.0.3
         version: 1.0.3
@@ -7959,28 +7959,19 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@branchlint/cli@1.1.0:
-    resolution: {integrity: sha512-iTYLrnCsyFtohuOgsHUXZAOkp7eGaFKY3ihGh1c5xF+VVePbNbZoum4XvlX9zzRD5UXURmVhm/FP16jaN6ovlw==}
+  /@branchlint/cli@1.0.5:
+    resolution: {integrity: sha512-lfURceyKvEOgNVOcDEg68zFcZyKk+z7m1ArWbmUftCFi86dSxSU/pYjh8cfb+mEQGZt7fpbdKAFgxcp2zsGG1A==}
     hasBin: true
     dependencies:
-      '@branchlint/default-config': 0.0.1
+      '@branchlint/common': 0.0.1
+      '@branchlint/default-config': 1.0.3
       inquirer: 8.0.1
-      lodash: 4.17.21
-      zod: 3.21.4
     dev: true
 
   /@branchlint/common@0.0.1:
     resolution: {integrity: sha512-8UFahntTD06LFh0ZsjrYL4Qpck4nJIbPozV91xalc6nLqLBYb2eDl0mZNczKwwedgVuHs1jV4/yO7YhvhwBsbA==}
     dependencies:
       inquirer: 8.0.1
-      zod: 3.21.4
-    dev: true
-
-  /@branchlint/default-config@0.0.1:
-    resolution: {integrity: sha512-mKK7k9l/qxhjHAnm5FYjraXeKkeRGVj4xad25bX31YLhRC07FpcHF/pYe4pbfuOVOYL3qpsEX3U8Jn1NyWpORQ==}
-    hasBin: true
-    dependencies:
-      lodash: 4.17.21
       zod: 3.21.4
     dev: true
 


### PR DESCRIPTION
### Description
Previously version `1.1.0` of `@branchlint/cli` was installed in `node_modules` instead of `1.0.5` due to lockfile.
