### PR TITLE
support multi arch docker images

### DIFF
--- a/.github/workflows/publish-backoffice.yml
+++ b/.github/workflows/publish-backoffice.yml
@@ -20,6 +20,9 @@ env:
 
 jobs:
   build-and-push-image:
+    strategy:
+      matrix:
+        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -72,7 +75,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/backoffice-v2
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           push: true
           tags: ${{ steps.branchmeta.outputs.tags }}
@@ -95,7 +98,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/backoffice-v2
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           push: true
           tags: ${{ steps.prodmeta.outputs.tags }}

--- a/.github/workflows/publish-headless-example.yml
+++ b/.github/workflows/publish-headless-example.yml
@@ -20,6 +20,9 @@ env:
 
 jobs:
   build-and-push-image:
+    strategy:
+      matrix:
+        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -72,7 +75,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: examples/headless-example
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
@@ -95,7 +98,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: examples/headless-example
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}

--- a/.github/workflows/publish-kyb-app.yml
+++ b/.github/workflows/publish-kyb-app.yml
@@ -20,6 +20,9 @@ env:
 
 jobs:
   build-and-push-image:
+    strategy:
+      matrix:
+        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,7 +82,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/kyb-app
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
@@ -102,7 +105,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/kyb-app
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}

--- a/.github/workflows/publish-websocket.yml
+++ b/.github/workflows/publish-websocket.yml
@@ -20,6 +20,9 @@ env:
 
 jobs:
   build-and-push-image:
+    strategy:
+      matrix:
+        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,7 +82,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: services/websocket-service
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
@@ -102,7 +105,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: services/websocket-service
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}

--- a/.github/workflows/publish-workflows-dashboard.yml
+++ b/.github/workflows/publish-workflows-dashboard.yml
@@ -20,6 +20,9 @@ env:
 
 jobs:
   build-and-push-image:
+    strategy:
+      matrix:
+        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -72,7 +75,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/workflows-dashboard
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
@@ -95,7 +98,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/workflows-dashboard
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}

--- a/.github/workflows/publish-workflows-service.yml
+++ b/.github/workflows/publish-workflows-service.yml
@@ -20,6 +20,9 @@ env:
 
 jobs:
   build-and-push-image:
+    strategy:
+      matrix:
+        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -85,7 +88,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: services/workflows-service
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}
@@ -95,7 +98,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: services/workflows-service
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}


### PR DESCRIPTION
Fixes: [1135](https://github.com/ballerine-io/ballerine/issues/1135)


This will help in building images both arm64 and amd64 docker images for ballerine. 

The benefit of this change is that this will build arm64 and amd64 images in parallel

Like follows:
<img width="1383" alt="image" src="https://github.com/ballerine-io/ballerine/assets/137189067/5c37553e-b7bd-43bb-b3f0-05a4c2ff1101">

The reason we have to do this is because building image on arm64 takes longer and thereby stalls the work of engineers who work on amd64 images. 
