### PR TITLE
Remove from entity block props represented in blocks of their own

### DIFF
--- a/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
@@ -382,11 +382,7 @@ export const useTasks = ({
                     ...Object.entries(
                       omitPropsFromObject(entity?.data, 'additionalInfo', 'address') ?? {},
                     ),
-                    ...Object.entries(
-                      workflow?.childWorkflows?.length
-                        ? omitPropsFromObject(entityDataAdditionalInfo ?? {}, 'ubos')
-                        : entityDataAdditionalInfo ?? {},
-                    ),
+                    ...Object.entries(omitPropsFromObject(entityDataAdditionalInfo ?? {}, 'ubos')),
                   ]
                     ?.map(([title, value]) => ({
                       title,

--- a/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
@@ -63,6 +63,7 @@ export const useTasks = ({
     directors: directorsUserProvided,
     mainRepresentative,
     mainContact,
+    ...entityDataAdditionalInfo
   } = workflow?.context?.entity?.data?.additionalInfo ?? {};
   const { website: websiteBasicRequirement, processingDetails, ...storeInfo } = store ?? {};
   const { data: session } = useAuthenticatedUserQuery();
@@ -381,7 +382,7 @@ export const useTasks = ({
                     ...Object.entries(
                       omitPropsFromObject(entity?.data, 'additionalInfo', 'address') ?? {},
                     ),
-                    ...Object.entries(entity?.data?.additionalInfo ?? {}),
+                    ...Object.entries(entityDataAdditionalInfo ?? {}),
                   ]
                     ?.map(([title, value]) => ({
                       title,

--- a/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
@@ -382,7 +382,11 @@ export const useTasks = ({
                     ...Object.entries(
                       omitPropsFromObject(entity?.data, 'additionalInfo', 'address') ?? {},
                     ),
-                    ...Object.entries(entityDataAdditionalInfo ?? {}),
+                    ...Object.entries(
+                      workflow?.childWorkflows?.length
+                        ? omitPropsFromObject(entityDataAdditionalInfo ?? {}, 'ubos')
+                        : entityDataAdditionalInfo ?? {},
+                    ),
                   ]
                     ?.map(([title, value]) => ({
                       title,


### PR DESCRIPTION
- refactor(backoffice-v2): removed props from the entity block which are already blocks themselves
- refactor(backoffice-v2): now removing the ubos property from entity block if rendering kyc blocks