### PR TITLE
Reordered task (documents) blocks to bottom of order

### DIFF
--- a/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
@@ -1099,7 +1099,6 @@ export const useTasks = ({
           ...entityInfoBlock,
           ...registryInfoBlock,
           ...companySanctionsBlock,
-          ...taskBlocks,
           ...directorsUserProvidedBlock,
           ...directorsRegistryProvidedBlock,
           ...ubosBlock,
@@ -1110,6 +1109,7 @@ export const useTasks = ({
           ...mainContactBlock,
           ...mainRepresentativeBlock,
           ...mapBlock,
+          ...taskBlocks,
         ]
       : [];
   }, [


### PR DESCRIPTION
### Description
Moved `taskBlocks` to the bottom of the blocks array.