### PR TITLE
Reverted registry info block to use plugins output

### DIFF
--- a/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
@@ -87,10 +87,15 @@ export const useTasks = ({
   const documentsSchemas = !!issuerCountryCode && getDocumentsByCountry(issuerCountryCode);
 
   const registryInfoBlock =
-    Object.keys(openCorporate ?? {}).length === 0
+    Object.keys(filteredPluginsOutput ?? {}).length === 0
       ? []
-      : [
-          {
+      : pluginsOutputKeys
+          ?.filter(
+            key =>
+              !!Object.keys(filteredPluginsOutput[key] ?? {})?.length &&
+              !('error' in filteredPluginsOutput[key]),
+          )
+          ?.map((key, index, collection) => ({
             cells: [
               {
                 type: 'container',
@@ -108,17 +113,16 @@ export const useTasks = ({
               },
               {
                 type: 'details',
-                hideSeparator: true,
+                hideSeparator: index === collection.length - 1,
                 value: {
-                  data: Object.entries(openCorporate ?? {})?.map(([title, value]) => ({
+                  data: Object.entries(filteredPluginsOutput[key] ?? {})?.map(([title, value]) => ({
                     title,
                     value,
                   })),
                 },
               },
             ],
-          },
-        ];
+          }));
 
   const taskBlocks =
     documents?.map(

--- a/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/useTasks.tsx
@@ -45,7 +45,7 @@ export const useTasks = ({
     directors: directorsUserProvided,
     mainRepresentative,
     mainContact,
-    openCorporate,
+    openCorporate: _openCorporate,
     ...entityDataAdditionalInfo
   } = workflow?.context?.entity?.data?.additionalInfo ?? {};
   const { website: websiteBasicRequirement, processingDetails, ...storeInfo } = store ?? {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         specifier: 0.7.13-3e08f108.6
         version: link:../../packages/common
       '@ballerine/ui':
-        specifier: 0.3.5-3e08f108.11
+        specifier: 0.3.5-3e08f108.12
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
         specifier: 0.5.11-3e08f108.7
@@ -634,7 +634,7 @@ importers:
         specifier: 0.1.11-3e08f108.7
         version: link:../../packages/blocks
       '@ballerine/ui':
-        specifier: 0.3.5-3e08f108.11
+        specifier: 0.3.5-3e08f108.12
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
         specifier: 0.5.11-3e08f108.7
@@ -36732,5 +36732,4 @@ packages:
   file:services/workflows-service/plugins/verify-repository-project-scoped:
     resolution: {directory: services/workflows-service/plugins/verify-repository-project-scoped, type: directory}
     name: eslint-plugin-ballerine
-    version: 1.0.0
     dev: true


### PR DESCRIPTION
- revert(backoffice-v2): registry info block is now using plugins output again for its data source
- refactor(backoffice-v2): refactored the openCorporate prop to indicate it is unused
