### PR TITLE
add: scan docker image as part of github actions

### DIFF
--- a/.github/workflows/publish-backoffice.yml
+++ b/.github/workflows/publish-backoffice.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           context: apps/backoffice-v2
           platforms: linux/amd64
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           push: true
           tags: ${{ steps.branchmeta.outputs.tags }}
 
@@ -95,5 +96,17 @@ jobs:
         with:
           context: apps/backoffice-v2
           platforms: linux/amd64
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           push: true
           tags: ${{ steps.prodmeta.outputs.tags }}
+
+
+      - name: Scan Docker Image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
+          format: 'table'
+          ignore-unfixed: true
+          exit-code: 1
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/publish-headless-example.yml
+++ b/.github/workflows/publish-headless-example.yml
@@ -74,6 +74,7 @@ jobs:
           context: examples/headless-example
           platforms: linux/amd64
           push: true
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
 
       - name: Extract metadata (tags, labels) for prod Docker images
@@ -96,4 +97,15 @@ jobs:
           context: examples/headless-example
           platforms: linux/amd64
           push: true
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}
+
+      - name: Scan Docker Image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
+          format: 'table'
+          ignore-unfixed: true
+          exit-code: 1
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/publish-kyb-app.yml
+++ b/.github/workflows/publish-kyb-app.yml
@@ -81,6 +81,7 @@ jobs:
           context: examples/kyb-app
           platforms: linux/amd64
           push: true
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
 
       - name: Extract metadata (tags, labels) for prod Docker images
@@ -103,4 +104,15 @@ jobs:
           context: examples/kyb-app
           platforms: linux/amd64
           push: true
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}
+
+      - name: Scan Docker Image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
+          format: 'table'
+          ignore-unfixed: true
+          exit-code: 1
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/publish-websocket.yml
+++ b/.github/workflows/publish-websocket.yml
@@ -81,6 +81,7 @@ jobs:
           context: services/websocket-service
           platforms: linux/amd64
           push: true
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
 
       - name: Extract metadata (tags, labels) for prod Docker images
@@ -103,4 +104,15 @@ jobs:
           context: services/websocket-service
           platforms: linux/amd64
           push: true
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}
+
+      - name: Scan Docker Image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
+          format: 'table'
+          ignore-unfixed: true
+          exit-code: 1
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/publish-workflows-dashboard.yml
+++ b/.github/workflows/publish-workflows-dashboard.yml
@@ -74,6 +74,7 @@ jobs:
           context: apps/workflows-dashboard
           platforms: linux/amd64
           push: true
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
 
       - name: Extract metadata (tags, labels) for prod Docker images
@@ -96,4 +97,15 @@ jobs:
           context: apps/workflows-dashboard
           platforms: linux/amd64
           push: true
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}
+
+      - name: Scan Docker Image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
+          format: 'table'
+          ignore-unfixed: true
+          exit-code: 1
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/publish-workflows-service.yml
+++ b/.github/workflows/publish-workflows-service.yml
@@ -87,6 +87,7 @@ jobs:
           context: services/workflows-service
           platforms: linux/amd64
           push: true
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}
 
       - name: Build and push Docker image for non Prod
@@ -96,4 +97,15 @@ jobs:
           context: services/workflows-service
           platforms: linux/amd64
           push: true
+          cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
+
+      - name: Scan Docker Image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
+          format: 'table'
+          ignore-unfixed: true
+          exit-code: 1
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
Scan docker images and exits or fails incase a severe or critical vulnerability is found 

Sample output in a forked repo:

![Uploading image.png…]()
