### PR TITLE
Updated definitions to not use process.env

### DIFF
--- a/services/workflows-service/scripts/workflows/dynamic-ui-workflow.ts
+++ b/services/workflows-service/scripts/workflows/dynamic-ui-workflow.ts
@@ -118,7 +118,7 @@ export const dynamicUiWorkflowDefinition = {
       {
         name: 'open_corporates',
         pluginKind: 'kyb',
-        url: `${env.UNIFIED_API_URL}/companies`,
+        url: `{secret.UNIFIED_API_URL}/companies`,
         method: 'GET',
         stateNames: ['run_kyb_enrichment'],
         successAction: 'KYB_DONE',

--- a/services/workflows-service/scripts/workflows/kyc-email-process-example.ts
+++ b/services/workflows-service/scripts/workflows/kyc-email-process-example.ts
@@ -85,7 +85,7 @@ export const kycEmailSessionDefinition = {
       {
         name: 'kyc_session',
         pluginKind: 'kyc-session',
-        url: `${env.UNIFIED_API_URL}/individual-verification-sessions`,
+        url: `{secret.UNIFIED_API_URL}/individual-verification-sessions`,
         method: 'POST',
         stateNames: ['get_kyc_session', 'get_kyc_session_revision'],
         successAction: 'SEND_EMAIL',


### PR DESCRIPTION
### Description
Using `secret` placeholder instead, now values are no longer visible outside of runtime.