### PR TITLE
Made assigning an id to documents more resilient

### DIFF
--- a/services/workflows-service/src/workflow/assign-id-to-documents.ts
+++ b/services/workflows-service/src/workflow/assign-id-to-documents.ts
@@ -5,8 +5,14 @@ export type TDocuments = DefaultContextSchema['documents'];
 
 export const assignIdToDocuments = (documents: TDocuments): TDocuments =>
   documents?.map(document => {
-    return {
+    const documentWithId = {
       ...document,
-      id: document.id ?? randomUUID(),
+      id: document.id || randomUUID(),
     };
+
+    if (!documentWithId?.id) {
+      console.error('Failed to assign an ID to a document\n', documentWithId);
+    }
+
+    return documentWithId;
   });

--- a/services/workflows-service/src/workflow/workflow-runtime-data.repository.intg.test.ts
+++ b/services/workflows-service/src/workflow/workflow-runtime-data.repository.intg.test.ts
@@ -127,7 +127,7 @@ describe('#Workflow Runtime Repository Integration Tests', () => {
                 id: '1',
                 name: 'TestEntity',
               },
-              documents: ['file1', 'file2'],
+              documents: [{ id: 'file1' }, { id: 'file2' }],
             },
           },
         },
@@ -140,7 +140,7 @@ describe('#Workflow Runtime Repository Integration Tests', () => {
           id: '2',
           name: 'UpdatedEntity',
         },
-        documents: ['file3'],
+        documents: [{ id: 'file3' }],
       };
 
       const res = await workflowRuntimeRepository.updateById(
@@ -159,7 +159,7 @@ describe('#Workflow Runtime Repository Integration Tests', () => {
           id: '2',
           name: 'UpdatedEntity',
         },
-        documents: ['file3'],
+        documents: [{ id: 'file3' }],
       });
     });
 

--- a/services/workflows-service/src/workflow/workflow-runtime-data.repository.ts
+++ b/services/workflows-service/src/workflow/workflow-runtime-data.repository.ts
@@ -82,6 +82,13 @@ export class WorkflowRuntimeDataRepository {
         {
           where: { id },
           ...args,
+          data: {
+            ...args.data,
+            context: {
+              ...((args.data?.context ?? {}) as any),
+              documents: assignIdToDocuments((args.data?.context as any)?.documents),
+            },
+          } as any,
         },
         projectId,
       ),

--- a/services/workflows-service/src/workflow/workflow-runtime-data.repository.ts
+++ b/services/workflows-service/src/workflow/workflow-runtime-data.repository.ts
@@ -101,7 +101,10 @@ export class WorkflowRuntimeDataRepository {
     arrayMergeOption: ArrayMergeOption = 'by_id',
     projectIds: TProjectIds,
   ): Promise<WorkflowRuntimeData> {
-    const stringifiedContext = JSON.stringify(newContext);
+    const stringifiedContext = JSON.stringify({
+      ...newContext,
+      documents: assignIdToDocuments(newContext?.documents),
+    });
     const affectedRows = await this.prisma
       .$executeRaw`UPDATE "WorkflowRuntimeData" SET "context" = jsonb_deep_merge_with_options("context", ${stringifiedContext}::jsonb, ${arrayMergeOption}) WHERE "id" = ${id} AND "projectId" in (${projectIds?.join(
       ',',


### PR DESCRIPTION
- fix(workflows-service): added assignIdToDocuments to update operation
- fix(workflows-service): added assignIdToDocuments to plv8 update method
- refactor(workflows-service): now checking for falsy instead of nullish for document.id and logging if document.id could not be assigned
