### PR TITLE
Add Config Param to Document Change Event in Workflows Service

### DIFF
--- a/services/workflows-service/src/events/document-changed-webhook-caller.ts
+++ b/services/workflows-service/src/events/document-changed-webhook-caller.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
-import { WorkflowEventEmitterService } from '@/workflow/workflow-event-emitter.service';
+import {
+  EventConfig,
+  WorkflowEventEmitterService,
+} from '@/workflow/workflow-event-emitter.service';
 import { Injectable } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { AxiosInstance } from 'axios';
@@ -37,9 +40,9 @@ export class DocumentChangedWebhookCaller {
   ) {
     this.#__axios = this.httpService.axiosRef;
 
-    workflowEventEmitter.on('workflow.context.changed', async data => {
+    workflowEventEmitter.on('workflow.context.changed', async (data, config) => {
       try {
-        await this.handleWorkflowEvent(data);
+        await this.handleWorkflowEvent(data, config);
       } catch (error) {
         console.error(error);
         alertWebhookFailure(error);
@@ -47,7 +50,10 @@ export class DocumentChangedWebhookCaller {
     });
   }
 
-  async handleWorkflowEvent(data: ExtractWorkflowEventData<'workflow.context.changed'>) {
+  async handleWorkflowEvent(
+    data: ExtractWorkflowEventData<'workflow.context.changed'>,
+    config: EventConfig = {},
+  ) {
     const oldDocuments = data.oldRuntimeData.context['documents'] || [];
     const newDocuments = data.updatedRuntimeData.context?.['documents'] || [];
 
@@ -67,19 +73,20 @@ export class DocumentChangedWebhookCaller {
       return accumulator;
     }, {});
 
-    const anyDocumentStatusChanged = oldDocuments.some((oldDocument: any) => {
-      const id = getDocumentId(oldDocument, false);
-      this.logger.log('handleWorkflowEvent::anyDocumentStatusChanged::getDocumentId::  ', {
-        idDoc: id,
-      });
-      return (
-        (!oldDocument.decision && newDocumentsByIdentifier[id]?.decision) ||
-        (oldDocument.decision &&
-          oldDocument.decision.status &&
-          id in newDocumentsByIdentifier &&
-          oldDocument.decision.status !== newDocumentsByIdentifier[id].decision?.status)
-      );
-    });
+    const anyDocumentStatusChanged =
+      oldDocuments.some((oldDocument: any) => {
+        const id = getDocumentId(oldDocument, false);
+        this.logger.log('handleWorkflowEvent::anyDocumentStatusChanged::getDocumentId::  ', {
+          idDoc: id,
+        });
+        return (
+          (!oldDocument.decision && newDocumentsByIdentifier[id]?.decision) ||
+          (oldDocument.decision &&
+            oldDocument.decision.status &&
+            id in newDocumentsByIdentifier &&
+            oldDocument.decision.status !== newDocumentsByIdentifier[id].decision?.status)
+        );
+      }) || config.forceEmit;
 
     if (!anyDocumentStatusChanged) {
       this.logger.log('handleWorkflowEvent:: Skipped, ', {

--- a/services/workflows-service/src/workflow/dtos/emit-system-event-input.ts
+++ b/services/workflows-service/src/workflow/dtos/emit-system-event-input.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class EmitSystemBodyInput {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  systemEventName!: string;
+
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  projectId!: string;
+}
+
+export class EmitSystemParamInput {
+  @ApiProperty({
+    required: true,
+    type: String,
+  })
+  @IsString()
+  id!: string;
+}

--- a/services/workflows-service/src/workflow/workflow-event-emitter.service.ts
+++ b/services/workflows-service/src/workflow/workflow-event-emitter.service.ts
@@ -6,6 +6,7 @@ export type EventConfig = {
   forceEmit?: boolean;
 };
 
+const DEFAULT_CONFIG = { forceEmit: false };
 @Injectable()
 export class WorkflowEventEmitterService {
   constructor(private eventEmitter: EventEmitter2) {}
@@ -13,8 +14,9 @@ export class WorkflowEventEmitterService {
   emit<TEvent extends TEventName>(
     eventName: TEvent,
     eventData: ExtractWorkflowEventData<TEvent>,
-    config = { forceEmit: false },
+    config?: EventConfig,
   ) {
+    config = { ...DEFAULT_CONFIG, ...(config || {}) };
     if (!eventName) {
       throw new Error('Event name is required');
     }

--- a/services/workflows-service/src/workflow/workflow-event-emitter.service.ts
+++ b/services/workflows-service/src/workflow/workflow-event-emitter.service.ts
@@ -2,21 +2,29 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Injectable } from '@nestjs/common';
 import { ExtractWorkflowEventData, TEventName } from '@/workflow/types';
 
+export type EventConfig = {
+  forceEmit?: boolean;
+};
+
 @Injectable()
 export class WorkflowEventEmitterService {
   constructor(private eventEmitter: EventEmitter2) {}
 
-  emit<TEvent extends TEventName>(eventName: TEvent, eventData: ExtractWorkflowEventData<TEvent>) {
+  emit<TEvent extends TEventName>(
+    eventName: TEvent,
+    eventData: ExtractWorkflowEventData<TEvent>,
+    config = { forceEmit: false },
+  ) {
     if (!eventName) {
       throw new Error('Event name is required');
     }
 
-    this.eventEmitter.emit(eventName, eventData);
+    this.eventEmitter.emit(eventName, eventData, config);
   }
 
   on<TEvent extends TEventName>(
     eventName: TEvent,
-    listener: (eventData: ExtractWorkflowEventData<TEvent>) => Promise<void>,
+    listener: (eventData: ExtractWorkflowEventData<TEvent>, config: EventConfig) => Promise<void>,
   ) {
     if (!eventName) {
       throw new Error('Event name is required');

--- a/services/workflows-service/src/workflow/workflow.controller.internal.ts
+++ b/services/workflows-service/src/workflow/workflow.controller.internal.ts
@@ -233,7 +233,7 @@ export class WorkflowControllerInternal {
       throw new common.BadRequestException(`Invalid system event name: ${data.systemEventName}`);
     }
     return await this.service.emitSystemWorkflowEvent({
-      workflowRuntimeId: params?.id,
+      workflowRuntimeId: params.id,
       projectId: data.projectId,
       systemEventName: data.systemEventName as 'workflow.context.changed',
     });

--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -2099,4 +2099,33 @@ export class WorkflowService {
       data,
     });
   }
+
+  async emitSystemWorkflowEvent({
+    workflowRuntimeId,
+    projectId,
+    systemEventName,
+  }: {
+    workflowRuntimeId: string;
+    projectId: string;
+    systemEventName: 'workflow.context.changed'; // currently supports only this event
+  }) {
+    const runtimeData = await this.workflowRuntimeDataRepository.findById(workflowRuntimeId, {}, [
+      projectId,
+    ]);
+    const correlationId = await this.getCorrelationIdFromWorkflow(runtimeData, [projectId]);
+
+    this.workflowEventEmitter.emit(
+      systemEventName,
+      {
+        oldRuntimeData: runtimeData,
+        updatedRuntimeData: runtimeData,
+        state: runtimeData.state as string,
+        entityId: (runtimeData.businessId || runtimeData.endUserId) as string,
+        correlationId: correlationId,
+      },
+      {
+        forceEmit: true,
+      },
+    );
+  }
 }


### PR DESCRIPTION
This PR introduces the following changes to the workflows-service:

- `document-changed-webhook-caller.ts` now accepts an `EventConfig` parameter to dictate event handling behavior.
- `workflow-event-emitter.service.ts` has been updated to handle the new `EventConfig` parameter.
- `workflow.controller.internal.ts` includes a new endpoint for system event emission with admin guard.
- `workflow.service.ts` supports emitting system workflow events, leveraging the new config parameter.

These changes enhance the flexibility of the event handling system, especially for cases where event emission should be forced.
