### PR TITLE
Fixed Prisma types resulting in any

### DIFF
--- a/services/workflows-service/src/auth/assignee-asigned-guard.service.ts
+++ b/services/workflows-service/src/auth/assignee-asigned-guard.service.ts
@@ -30,6 +30,7 @@ export class WorkflowAssigneeGuard implements CanActivate {
 
     return (
       workflowRuntime.assigneeId === requestingUserId ||
+      // @ts-ignore - fix type from include/select not propagating from repository
       workflowRuntime.parentWorkflowRuntimeData?.assigneeId === requestingUserId
     );
   }

--- a/services/workflows-service/src/collection-flow/collection-flow.service.ts
+++ b/services/workflows-service/src/collection-flow/collection-flow.service.ts
@@ -106,13 +106,13 @@ export class CollectionFlowService {
       {
         data: {
           definition: {
-            // @ts-expect-error - revisit after JSONB validation task - #_INFECTED_
+            // @ts-expect-error - revisit after JSONB validation task - error from Prisma types fix
             ...definition?.definition,
             states: {
-              // @ts-expect-error - revisit after JSONB validation task - #_INFECTED_
+              // @ts-expect-error - revisit after JSONB validation task - error from Prisma types fix
               ...definition.definition?.states,
               data_collection: {
-                // @ts-expect-error - revisit after JSONB validation task - #_INFECTED_
+                // @ts-expect-error - revisit after JSONB validation task - error from Prisma types fix
                 ...definition.definition?.states?.data_collection,
                 metadata: {
                   uiSettings: {
@@ -132,7 +132,7 @@ export class CollectionFlowService {
     return plainToClass(FlowConfigurationModel, {
       id: updatedDefinition.id,
       steps:
-        // @ts-expect-error - revisit after JSONB validation task - #_INFECTED_
+        // @ts-expect-error - revisit after JSONB validation task - error from Prisma types fix
         updatedDefinition.definition?.states?.data_collection?.metadata?.uiSettings?.multiForm
           ?.steps || [],
     });

--- a/services/workflows-service/src/collection-flow/collection-flow.service.ts
+++ b/services/workflows-service/src/collection-flow/collection-flow.service.ts
@@ -89,6 +89,7 @@ export class CollectionFlowService {
     const providedStepsMap = keyBy(steps, 'key');
 
     const persistedSteps =
+      // @ts-expect-error - error from Prisma types fix
       definition.definition?.states?.data_collection?.metadata?.uiSettings?.multiForm?.steps || [];
 
     const mergedSteps = persistedSteps.map((step: any) => {

--- a/services/workflows-service/src/collection-flow/collection-flow.service.ts
+++ b/services/workflows-service/src/collection-flow/collection-flow.service.ts
@@ -89,7 +89,7 @@ export class CollectionFlowService {
     const providedStepsMap = keyBy(steps, 'key');
 
     const persistedSteps =
-      definition.definition.states?.data_collection?.metadata?.uiSettings?.multiForm?.steps || [];
+      definition.definition?.states?.data_collection?.metadata?.uiSettings?.multiForm?.steps || [];
 
     const mergedSteps = persistedSteps.map((step: any) => {
       const stepToMergeIn = providedStepsMap[step.key];
@@ -106,10 +106,13 @@ export class CollectionFlowService {
       {
         data: {
           definition: {
-            ...definition.definition,
+            // @ts-expect-error - revisit after JSONB validation task - #_INFECTED_
+            ...definition?.definition,
             states: {
+              // @ts-expect-error - revisit after JSONB validation task - #_INFECTED_
               ...definition.definition?.states,
               data_collection: {
+                // @ts-expect-error - revisit after JSONB validation task - #_INFECTED_
                 ...definition.definition?.states?.data_collection,
                 metadata: {
                   uiSettings: {
@@ -129,6 +132,7 @@ export class CollectionFlowService {
     return plainToClass(FlowConfigurationModel, {
       id: updatedDefinition.id,
       steps:
+        // @ts-expect-error - revisit after JSONB validation task - #_INFECTED_
         updatedDefinition.definition?.states?.data_collection?.metadata?.uiSettings?.multiForm
           ?.steps || [],
     });

--- a/services/workflows-service/src/collection-flow/workflow-adapters/kyb_parent_kyc_session_example/kyb_parent_kyc_session_example.workflow-adapter.ts
+++ b/services/workflows-service/src/collection-flow/workflow-adapters/kyb_parent_kyc_session_example/kyb_parent_kyc_session_example.workflow-adapter.ts
@@ -13,7 +13,7 @@ export class KYBParentKYCSessionExampleAdapter
     flowData.id = workflow.id;
     flowData.flowData = context?.entity?.data?.dynamicInfo || {};
     flowData.flowState = context?.entity?.data?.__stateKey || null;
-    // @ts-expect-error - #_INFECTED_
+    // @ts-expect-error - error from Prisma types fix
     flowData.status = workflow.state;
     flowData.isFinished = context?.entity?.data?.__isFinished || false;
     flowData.documents = context?.documents;

--- a/services/workflows-service/src/collection-flow/workflow-adapters/kyb_parent_kyc_session_example/kyb_parent_kyc_session_example.workflow-adapter.ts
+++ b/services/workflows-service/src/collection-flow/workflow-adapters/kyb_parent_kyc_session_example/kyb_parent_kyc_session_example.workflow-adapter.ts
@@ -13,6 +13,7 @@ export class KYBParentKYCSessionExampleAdapter
     flowData.id = workflow.id;
     flowData.flowData = context?.entity?.data?.dynamicInfo || {};
     flowData.flowState = context?.entity?.data?.__stateKey || null;
+    // @ts-expect-error - #_INFECTED_
     flowData.status = workflow.state;
     flowData.isFinished = context?.entity?.data?.__isFinished || false;
     flowData.documents = context?.documents;

--- a/services/workflows-service/src/common/utils/log-document-without-id/log-document-without-id.ts
+++ b/services/workflows-service/src/common/utils/log-document-without-id/log-document-without-id.ts
@@ -13,11 +13,12 @@ export const logDocumentWithoutId = ({
 }) => {
   workflowRuntimeData?.context?.documents?.forEach(
     (document: DefaultContextSchema['documents'][number]) => {
-      if (!!document?.id) return;
+      if (document?.id) return;
 
       logger.error('Document without an ID was found', {
         line,
         workflowRuntimeDataId: workflowRuntimeData?.id,
+        // @ts-expect-error - #_INFECTED_
         workflowDefinitionId: workflowRuntimeData?.workflowDefinition?.id,
         entity: {
           id: workflowRuntimeData?.context?.entity?.id,

--- a/services/workflows-service/src/common/utils/log-document-without-id/log-document-without-id.ts
+++ b/services/workflows-service/src/common/utils/log-document-without-id/log-document-without-id.ts
@@ -18,7 +18,7 @@ export const logDocumentWithoutId = ({
       logger.error('Document without an ID was found', {
         line,
         workflowRuntimeDataId: workflowRuntimeData?.id,
-        // @ts-expect-error - #_INFECTED_
+        // @ts-expect-error - error from Prisma types fix
         workflowDefinitionId: workflowRuntimeData?.workflowDefinition?.id,
         entity: {
           id: workflowRuntimeData?.context?.entity?.id,

--- a/services/workflows-service/src/events/document-changed-webhook-caller.ts
+++ b/services/workflows-service/src/events/document-changed-webhook-caller.ts
@@ -111,11 +111,15 @@ export class DocumentChangedWebhookCaller {
       });
     });
 
-    const customer = await this.customerService.getByProjectId(data.updatedRuntimeData.projectId, {
-      select: {
-        authenticationConfiguration: true,
+    const customer = await this.customerService.getByProjectId(
+      // @ts-expect-error - #_INFECTED_
+      data.updatedRuntimeData.projectId,
+      {
+        select: {
+          authenticationConfiguration: true,
+        },
       },
-    });
+    );
 
     const { webhookSharedSecret } =
       customer.authenticationConfiguration as TAuthenticationConfiguration;

--- a/services/workflows-service/src/events/document-changed-webhook-caller.ts
+++ b/services/workflows-service/src/events/document-changed-webhook-caller.ts
@@ -112,7 +112,7 @@ export class DocumentChangedWebhookCaller {
     });
 
     const customer = await this.customerService.getByProjectId(
-      // @ts-expect-error - #_INFECTED_
+      // @ts-expect-error - error from Prisma types fix
       data.updatedRuntimeData.projectId,
       {
         select: {

--- a/services/workflows-service/src/events/workflow-completed-webhook-caller.ts
+++ b/services/workflows-service/src/events/workflow-completed-webhook-caller.ts
@@ -58,11 +58,15 @@ export class WorkflowCompletedWebhookCaller {
       'workflow.completed',
     );
 
-    const customer = await this.customerService.getByProjectId(data.runtimeData.projectId, {
-      select: {
-        authenticationConfiguration: true,
+    const customer = await this.customerService.getByProjectId(
+      // @ts-expect-error - error from Prisma types fix
+      data.runtimeData.projectId,
+      {
+        select: {
+          authenticationConfiguration: true,
+        },
       },
-    });
+    );
 
     const { webhookSharedSecret } =
       customer.authenticationConfiguration as TAuthenticationConfiguration;
@@ -150,6 +154,7 @@ export class WorkflowCompletedWebhookCaller {
 
     let status: (typeof statusMap)[keyof typeof statusMap] | undefined;
 
+    // @ts-expect-error - error from Prisma types fix
     workflowRuntimeData.tags?.some((tag: string) => {
       if (tag in statusMap) {
         status = statusMap[tag as keyof typeof statusMap];

--- a/services/workflows-service/src/events/workflow-state-changed-webhook-caller.ts
+++ b/services/workflows-service/src/events/workflow-state-changed-webhook-caller.ts
@@ -52,11 +52,15 @@ export class WorkflowStateChangedWebhookCaller {
       'workflow.state.changed',
     );
 
-    const customer = await this.customerService.getByProjectId(data.runtimeData.projectId, {
-      select: {
-        authenticationConfiguration: true,
+    const customer = await this.customerService.getByProjectId(
+      // @ts-expect-error - error from Prisma types fix
+      data.runtimeData.projectId,
+      {
+        select: {
+          authenticationConfiguration: true,
+        },
       },
-    });
+    );
 
     const { webhookSharedSecret } =
       customer.authenticationConfiguration as TAuthenticationConfiguration;

--- a/services/workflows-service/src/global.d.ts
+++ b/services/workflows-service/src/global.d.ts
@@ -1,5 +1,3 @@
-import { type } from 'os';
-
 declare module '@prisma/client' {
   import type {
     WorkflowRuntimeData as _WorkflowRuntimeData,

--- a/services/workflows-service/src/workflow/types/index.ts
+++ b/services/workflows-service/src/workflow/types/index.ts
@@ -1,6 +1,7 @@
 import { SortOrder } from '@/common/query-filters/sort-order';
 import { WorkflowRuntimeListItemModel } from '@/workflow/workflow-runtime-list-item.model';
 import {
+  ApprovalState,
   Business,
   EndUser,
   WorkflowDefinition,
@@ -55,7 +56,7 @@ export interface IWorkflowContextChangedEventData {
   eventName: 'workflow.context.changed';
   oldRuntimeData: WorkflowRuntimeData;
   updatedRuntimeData: WorkflowRuntimeData;
-  state: string;
+  state: string | null;
   entityId: string;
   correlationId: string;
 }
@@ -64,7 +65,7 @@ export interface IWorkflowCompletedEventData {
   eventName: 'workflow.completed';
   // TODO: Move to a shared package
   runtimeData: WorkflowRuntimeData;
-  state: string;
+  state: string | null;
   entityId: string;
   correlationId: string;
 }
@@ -72,7 +73,7 @@ export interface IWorkflowCompletedEventData {
 export interface IWorkflowStateChangedEventData {
   eventName: 'workflow.state.changed';
   runtimeData: WorkflowRuntimeData;
-  state: string;
+  state: string | null;
   entityId: string;
   correlationId: string;
 }

--- a/services/workflows-service/src/workflow/workflow.controller.external.ts
+++ b/services/workflows-service/src/workflow/workflow.controller.external.ts
@@ -278,7 +278,9 @@ export class WorkflowControllerExternal {
         data: hookResponse,
         resultDestinationPath: query.resultDestination || 'hookResponse',
         processName: query.processName,
+        // @ts-expect-error - #_INFECTED_
         projectIds: [workflowRuntime.projectId],
+        // @ts-expect-error - #_INFECTED_
         currentProjectId: workflowRuntime.projectId,
       });
 
@@ -287,6 +289,7 @@ export class WorkflowControllerExternal {
           id: params.id,
           name: params.event,
         },
+        // @ts-expect-error - #_INFECTED_
         [workflowRuntime.projectId],
         workflowRuntime.projectId,
       );

--- a/services/workflows-service/src/workflow/workflow.controller.external.ts
+++ b/services/workflows-service/src/workflow/workflow.controller.external.ts
@@ -278,9 +278,9 @@ export class WorkflowControllerExternal {
         data: hookResponse,
         resultDestinationPath: query.resultDestination || 'hookResponse',
         processName: query.processName,
-        // @ts-expect-error - #_INFECTED_
+        // @ts-expect-error - error from Prisma types fix
         projectIds: [workflowRuntime.projectId],
-        // @ts-expect-error - #_INFECTED_
+        // @ts-expect-error - error from Prisma types fix
         currentProjectId: workflowRuntime.projectId,
       });
 
@@ -289,7 +289,7 @@ export class WorkflowControllerExternal {
           id: params.id,
           name: params.event,
         },
-        // @ts-expect-error - #_INFECTED_
+        // @ts-expect-error - error from Prisma types fix
         [workflowRuntime.projectId],
         workflowRuntime.projectId,
       );

--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -280,6 +280,7 @@ export class WorkflowService {
           : workflow.business.approvalState,
       },
       endUser: undefined,
+      // @ts-expect-error - error from Prisma types fix
       business: undefined,
       nextEvents,
       childWorkflows: workflow.childWorkflowsRuntimeData?.map(childWorkflow =>
@@ -1462,6 +1463,7 @@ export class WorkflowService {
               documents: documentsWithPersistedImages,
             } as InputJsonValue,
             config: mergedConfig as InputJsonValue,
+            // @ts-expect-error - error from Prisma types fix
             state: workflowDefinition.definition.initial as string,
             status: 'active',
             workflowDefinitionId: workflowDefinition.id,

--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -245,10 +245,13 @@ export class WorkflowService {
     if (addNextEvents) {
       const service = createWorkflow({
         runtimeId: workflow.id,
+        // @ts-expect-error - #_INFECTED_
         definition: workflow.workflowDefinition.definition,
-        definitionType: workflow.workflowDefinition.definitionType,
+        // Might want to change to type string in `createWorkflow` or add a type for `workflowDefinition` of 'statechart-json' | 'bpmn-json'
+        definitionType: workflow.workflowDefinition.definitionType as 'statechart-json',
         workflowContext: {
           machineContext: workflow.context,
+          // @ts-expect-error - #_INFECTED_
           state: workflow.state ?? workflow.workflowDefinition.definition?.initial,
         },
       });
@@ -256,7 +259,6 @@ export class WorkflowService {
       nextEvents = service.getSnapshot().nextEvents;
     }
 
-    // @ts-expect-error - typescript does not like recurrsion over types
     return {
       ...workflow,
       context: {
@@ -879,6 +881,7 @@ export class WorkflowService {
         this.workflowEventEmitter.emit('workflow.completed', {
           runtimeData: updatedWorkflow,
           state: updatedWorkflow.state,
+          // @ts-expect-error - #_INFECTED_
           entityId: updatedWorkflow.businessId || updatedWorkflow.endUserId,
           correlationId,
         });
@@ -1080,6 +1083,7 @@ export class WorkflowService {
       this.workflowEventEmitter.emit('workflow.completed', {
         runtimeData: updatedResult,
         state: currentState ?? updatedResult.state,
+        // @ts-expect-error - #_INFECTED_
         entityId: updatedResult.businessId || updatedResult.endUserId,
         correlationId,
       });
@@ -1534,9 +1538,9 @@ export class WorkflowService {
 
       if ('salesforceObjectName' in salesforceData && salesforceData.salesforceObjectName) {
         await this.updateSalesforceRecord({
-          workflowRuntimeData: workflowRuntimeData[0].workflowRuntimeData,
+          workflowRuntimeData,
           data: {
-            KYB_Started_At__c: workflowRuntimeData[0].workflowRuntimeData.createdAt,
+            KYB_Started_At__c: workflowRuntimeData.createdAt,
             KYB_Status__c: 'In Progress',
             KYB_Assigned_Agent__c: '',
           },
@@ -1724,6 +1728,7 @@ export class WorkflowService {
   ) {
     if (!Object.keys(workflowDefinition?.contextSchema ?? {}).length) return;
 
+    // @ts-expect-error - #_INFECTED_
     const validate = ajv.compile(workflowDefinition?.contextSchema?.schema); // TODO: fix type
     const isValid = validate({
       ...context,
@@ -1767,12 +1772,15 @@ export class WorkflowService {
 
     const service = createWorkflow({
       runtimeId: workflowRuntimeData.id,
+      // @ts-expect-error - #_INFECTED_
       definition: workflowDefinition.definition,
+      // @ts-expect-error - #_INFECTED_
       definitionType: workflowDefinition.definitionType,
       workflowContext: {
         machineContext: workflowRuntimeData.context,
         state: workflowRuntimeData.state,
       },
+      // @ts-expect-error - #_INFECTED_
       extensions: workflowDefinition.extensions,
       invokeChildWorkflowAction: async (childPluginConfiguration: ChildPluginCallbackOutput) => {
         const runnableChildWorkflow = await this.persistChildEvent(
@@ -1841,9 +1849,10 @@ export class WorkflowService {
     }
 
     this.workflowEventEmitter.emit('workflow.state.changed', {
+      // @ts-expect-error - #_INFECTED_
       entityId,
       state: updatedRuntimeData.state,
-      correlationId: updatedRuntimeData.correlationId,
+      correlationId: updatedRuntimeData.context.ballerineEntityId,
       runtimeData: updatedRuntimeData,
     });
 
@@ -1897,6 +1906,7 @@ export class WorkflowService {
     childRuntimeState?: string,
   ) {
     const parentWorkflowRuntime = await this.getWorkflowRuntimeWithChildrenDataById(
+      // @ts-expect-error - #_INFECTED_
       workflowRuntimeData.parentRuntimeDataId,
       { include: { childWorkflowsRuntimeData: true } },
       projectIds,
@@ -2093,8 +2103,11 @@ export class WorkflowService {
     };
   }) {
     return await this.salesforceService.updateRecord({
+      // @ts-expect-error - #__INFECTED__
       projectId: workflowRuntimeData.projectId,
+      // @ts-expect-error - #__INFECTED__
       objectName: workflowRuntimeData.salesforceObjectName,
+      // @ts-expect-error - #__INFECTED__
       recordId: workflowRuntimeData.salesforceRecordId,
       data,
     });

--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -1087,7 +1087,7 @@ export class WorkflowService {
       this.workflowEventEmitter.emit('workflow.completed', {
         runtimeData: updatedResult,
         state: currentState ?? updatedResult.state,
-        // @ts-expect-error - error from Prisma types fix
+        // @ts-ignore - error from Prisma types fix
         entityId: updatedResult.businessId || updatedResult.endUserId,
         correlationId,
       });

--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -245,13 +245,13 @@ export class WorkflowService {
     if (addNextEvents) {
       const service = createWorkflow({
         runtimeId: workflow.id,
-        // @ts-expect-error - #_INFECTED_
+        // @ts-expect-error - error from Prisma types fix
         definition: workflow.workflowDefinition.definition,
         // Might want to change to type string in `createWorkflow` or add a type for `workflowDefinition` of 'statechart-json' | 'bpmn-json'
         definitionType: workflow.workflowDefinition.definitionType as 'statechart-json',
         workflowContext: {
           machineContext: workflow.context,
-          // @ts-expect-error - #_INFECTED_
+          // @ts-expect-error - error from Prisma types fix
           state: workflow.state ?? workflow.workflowDefinition.definition?.initial,
         },
       });
@@ -881,7 +881,7 @@ export class WorkflowService {
         this.workflowEventEmitter.emit('workflow.completed', {
           runtimeData: updatedWorkflow,
           state: updatedWorkflow.state,
-          // @ts-expect-error - #_INFECTED_
+          // @ts-expect-error - error from Prisma types fix
           entityId: updatedWorkflow.businessId || updatedWorkflow.endUserId,
           correlationId,
         });
@@ -1031,6 +1031,9 @@ export class WorkflowService {
         parentMachine?.id,
         {
           data: {
+            status: 'active',
+            // @ts-expect-error - error from Prisma types fix
+            state: parentMachine?.workflowDefinition?.definition?.initial as string,
             context: {
               ...parentMachine?.context,
               documents: parentMachine?.context?.documents?.map((document: any) => {
@@ -1083,7 +1086,7 @@ export class WorkflowService {
       this.workflowEventEmitter.emit('workflow.completed', {
         runtimeData: updatedResult,
         state: currentState ?? updatedResult.state,
-        // @ts-expect-error - #_INFECTED_
+        // @ts-expect-error - error from Prisma types fix
         entityId: updatedResult.businessId || updatedResult.endUserId,
         correlationId,
       });
@@ -1728,7 +1731,7 @@ export class WorkflowService {
   ) {
     if (!Object.keys(workflowDefinition?.contextSchema ?? {}).length) return;
 
-    // @ts-expect-error - #_INFECTED_
+    // @ts-expect-error - error from Prisma types fix
     const validate = ajv.compile(workflowDefinition?.contextSchema?.schema); // TODO: fix type
     const isValid = validate({
       ...context,
@@ -1772,15 +1775,15 @@ export class WorkflowService {
 
     const service = createWorkflow({
       runtimeId: workflowRuntimeData.id,
-      // @ts-expect-error - #_INFECTED_
+      // @ts-expect-error - error from Prisma types fix
       definition: workflowDefinition.definition,
-      // @ts-expect-error - #_INFECTED_
+      // @ts-expect-error - error from Prisma types fix
       definitionType: workflowDefinition.definitionType,
       workflowContext: {
         machineContext: workflowRuntimeData.context,
         state: workflowRuntimeData.state,
       },
-      // @ts-expect-error - #_INFECTED_
+      // @ts-expect-error - error from Prisma types fix
       extensions: workflowDefinition.extensions,
       invokeChildWorkflowAction: async (childPluginConfiguration: ChildPluginCallbackOutput) => {
         const runnableChildWorkflow = await this.persistChildEvent(
@@ -1849,7 +1852,7 @@ export class WorkflowService {
     }
 
     this.workflowEventEmitter.emit('workflow.state.changed', {
-      // @ts-expect-error - #_INFECTED_
+      // @ts-expect-error - error from Prisma types fix
       entityId,
       state: updatedRuntimeData.state,
       correlationId: updatedRuntimeData.context.ballerineEntityId,
@@ -1906,7 +1909,7 @@ export class WorkflowService {
     childRuntimeState?: string,
   ) {
     const parentWorkflowRuntime = await this.getWorkflowRuntimeWithChildrenDataById(
-      // @ts-expect-error - #_INFECTED_
+      // @ts-expect-error - error from Prisma types fix
       workflowRuntimeData.parentRuntimeDataId,
       { include: { childWorkflowsRuntimeData: true } },
       projectIds,
@@ -1929,6 +1932,7 @@ export class WorkflowService {
           workflowDefinition.config.callbackResult!) as ChildWorkflowCallback;
 
         const childrenOfSameDefinition = (
+          // @ts-ignore - error from prisma types fix
           parentWorkflowRuntime.childWorkflowsRuntimeData as Array<WorkflowRuntimeData>
         )?.filter(
           childWorkflow =>

--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -1933,13 +1933,11 @@ export class WorkflowService {
         const childWorkflowCallback = (callbackTransformation ||
           workflowDefinition.config.callbackResult!) as ChildWorkflowCallback;
 
-        const childrenOfSameDefinition = (
-          // @ts-ignore - error from prisma types fix
-          parentWorkflowRuntime.childWorkflowsRuntimeData as Array<WorkflowRuntimeData>
-        )?.filter(
-          childWorkflow =>
-            childWorkflow.workflowDefinitionId === workflowRuntimeData.workflowDefinitionId,
-        );
+        const childrenOfSameDefinition = // @ts-ignore - error from Prisma types fix
+          (parentWorkflowRuntime.childWorkflowsRuntimeData as Array<WorkflowRuntimeData>)?.filter(
+            childWorkflow =>
+              childWorkflow.workflowDefinitionId === workflowRuntimeData.workflowDefinitionId,
+          );
 
         const isPersistableState =
           !!(

--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -2107,11 +2107,11 @@ export class WorkflowService {
     };
   }) {
     return await this.salesforceService.updateRecord({
-      // @ts-expect-error - #__INFECTED__
+      // @ts-expect-error - error from Prisma types fix
       projectId: workflowRuntimeData.projectId,
-      // @ts-expect-error - #__INFECTED__
+      // @ts-expect-error - error from Prisma types fix
       objectName: workflowRuntimeData.salesforceObjectName,
-      // @ts-expect-error - #__INFECTED__
+      // @ts-expect-error - error from Prisma types fix
       recordId: workflowRuntimeData.salesforceRecordId,
       data,
     });


### PR DESCRIPTION
### Description
Removed unused imports which caused Prisma types to be type `any` - for now type errors are commented by `@ts-expect-error` which will be fixed in a separate PR.

