### PR TITLE
Image viewer items no longer look stretched

### DIFF
--- a/apps/backoffice-v2/src/common/components/atoms/BallerineImage/BallerineImage.tsx
+++ b/apps/backoffice-v2/src/common/components/atoms/BallerineImage/BallerineImage.tsx
@@ -68,7 +68,7 @@ export const BallerineImage = forwardRef<HTMLImageElement, IBallerineImageProps>
         src={src}
         className={ctw(
           // Ensures the alt text doesn't overflow
-          `break-words rounded-md object-fill object-center`,
+          `break-words rounded-md object-cover object-center`,
           className,
         )}
         ref={ref}


### PR DESCRIPTION
### Description
![image](https://github.com/ballerine-io/ballerine/assets/61207713/c59a9069-ecfd-46cc-ad3b-8d4d2f076616)