### PR TITLE
Moved object-cover class to the image viewer item component

### DIFF
--- a/apps/backoffice-v2/src/common/components/atoms/BallerineImage/BallerineImage.tsx
+++ b/apps/backoffice-v2/src/common/components/atoms/BallerineImage/BallerineImage.tsx
@@ -68,7 +68,7 @@ export const BallerineImage = forwardRef<HTMLImageElement, IBallerineImageProps>
         src={src}
         className={ctw(
           // Ensures the alt text doesn't overflow
-          `break-words rounded-md object-cover object-center`,
+          `break-words rounded-md object-fill object-center`,
           className,
         )}
         ref={ref}

--- a/apps/backoffice-v2/src/common/components/organisms/ImageViewer/ImageViewer.Item.tsx
+++ b/apps/backoffice-v2/src/common/components/organisms/ImageViewer/ImageViewer.Item.tsx
@@ -55,6 +55,7 @@ export const Item: FunctionComponent<IItemProps> = ({
             src={src}
             className={ctw(
               `
+            object-cover
             group-hover:outline
             group-focus:outline
             group-hover:outline-2


### PR DESCRIPTION
### Description
Previously the image class was applied to unrelated components (all instances of `BallerineImage`)
