### PR TITLE
Fix failing image build on workflows-service

### DIFF
--- a/services/workflows-service/Dockerfile
+++ b/services/workflows-service/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 COPY ./package.json .
 
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 COPY . .
 


### PR DESCRIPTION
### Description
Image building was failing due to conflicting peer deps versions.