### PR TITLE
fix: multi-arch docker images for ballerine

### DIFF
--- a/.github/workflows/publish-backoffice.yml
+++ b/.github/workflows/publish-backoffice.yml
@@ -20,9 +20,6 @@ env:
 
 jobs:
   build-and-push-image:
-    strategy:
-      matrix:
-        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,7 +72,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/backoffice-v2
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           push: true
           tags: ${{ steps.branchmeta.outputs.tags }}
@@ -98,7 +95,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/backoffice-v2
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           push: true
           tags: ${{ steps.prodmeta.outputs.tags }}

--- a/.github/workflows/publish-headless-example.yml
+++ b/.github/workflows/publish-headless-example.yml
@@ -20,9 +20,6 @@ env:
 
 jobs:
   build-and-push-image:
-    strategy:
-      matrix:
-        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,7 +72,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: examples/headless-example
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
@@ -98,7 +95,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: examples/headless-example
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}

--- a/.github/workflows/publish-kyb-app.yml
+++ b/.github/workflows/publish-kyb-app.yml
@@ -20,9 +20,6 @@ env:
 
 jobs:
   build-and-push-image:
-    strategy:
-      matrix:
-        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,7 +79,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/kyb-app
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
@@ -105,7 +102,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/kyb-app
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}

--- a/.github/workflows/publish-websocket.yml
+++ b/.github/workflows/publish-websocket.yml
@@ -20,9 +20,6 @@ env:
 
 jobs:
   build-and-push-image:
-    strategy:
-      matrix:
-        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,7 +79,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: services/websocket-service
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
@@ -105,7 +102,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: services/websocket-service
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}

--- a/.github/workflows/publish-workflows-dashboard.yml
+++ b/.github/workflows/publish-workflows-dashboard.yml
@@ -20,9 +20,6 @@ env:
 
 jobs:
   build-and-push-image:
-    strategy:
-      matrix:
-        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,7 +72,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/workflows-dashboard
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.branchmeta.outputs.tags }}
@@ -98,7 +95,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: apps/workflows-dashboard
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.head_ref || github.ref_name }}'
           tags: ${{ steps.prodmeta.outputs.tags }}

--- a/.github/workflows/publish-workflows-service.yml
+++ b/.github/workflows/publish-workflows-service.yml
@@ -21,9 +21,6 @@ env:
 
 jobs:
   build-and-push-image:
-    strategy:
-      matrix:
-        platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -89,7 +86,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: services/workflows-service
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BRANCH_NAME }}'
           tags: ${{ steps.prodmeta.outputs.tags }}
@@ -99,7 +96,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: services/workflows-service
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64
           push: true
           cache-from: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BRANCH_NAME }}'
           tags: ${{ steps.branchmeta.outputs.tags }}


### PR DESCRIPTION
If the image is pushed it should have the following :

<img width="1068" alt="image" src="https://github.com/ballerine-io/ballerine/assets/137189067/11199ac1-3834-4981-8e9a-2b7ca448922d">


Working on a branch in ballerine

<img width="1141" alt="image" src="https://github.com/ballerine-io/ballerine/assets/137189067/400a9649-1278-4d16-9673-ce80e5956b97">
