### PR TITLE
fix: fixed bug where directors/ubo errors didnt appear on continue click

### DIFF
--- a/apps/kyb-app/src/common/consts/consts.ts
+++ b/apps/kyb-app/src/common/consts/consts.ts
@@ -1,0 +1,1 @@
+export const ARRAY_VALUE_INDEX_PLACEHOLDER = `{INDEX}`;

--- a/apps/kyb-app/src/components/organisms/DynamicUI/rule-engines/json-schema.rule-engine.ts
+++ b/apps/kyb-app/src/components/organisms/DynamicUI/rule-engines/json-schema.rule-engine.ts
@@ -59,7 +59,6 @@ export class JsonSchemaRuleEngine implements RuleEngine {
 
         messages?.forEach(messageText => {
           const sanitizedFieldId = fieldDestination.replaceAll(/\.(\d+)\./g, '[$1].');
-
           fieldErrors.push(
             this.createFieldError(
               sanitizedFieldId,

--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/hocs/withDynamicUIInput/withDynamicUIInput.tsx
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/hocs/withDynamicUIInput/withDynamicUIInput.tsx
@@ -1,3 +1,4 @@
+import { ARRAY_VALUE_INDEX_PLACEHOLDER } from '@/common/consts/consts';
 import { usePageResolverContext } from '@/components/organisms/DynamicUI/PageResolver/hooks/usePageResolverContext';
 import { useStateManagerContext } from '@/components/organisms/DynamicUI/StateManager/components/StateProvider';
 import { useDynamicUIContext } from '@/components/organisms/DynamicUI/hooks/useDynamicUIContext';
@@ -29,7 +30,7 @@ const getInputIndex = (inputId: string) => findLastDigit(inputId);
 const injectIndexToDestinationIfNeeded = (destination: string, index: number | null): string => {
   if (index === null) return destination;
 
-  const result = destination.replace(`{INDEX}`, `${index}`);
+  const result = destination.replace(ARRAY_VALUE_INDEX_PLACEHOLDER, `${index}`);
 
   return result;
 };

--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/SubmitButton/helpers.ts
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/SubmitButton/helpers.ts
@@ -1,22 +1,42 @@
+import { ARRAY_VALUE_INDEX_PLACEHOLDER } from '@/common/consts/consts';
 import { UIElement, UIPage } from '@/domains/collection-flow';
 import { AnyObject } from '@ballerine/ui';
 
-export const getElementNames = (page: UIPage) => {
-  const elementNames: string[] = [];
+export const getElementByValueDestination = (
+  destination: string,
+  page: UIPage,
+): UIElement<AnyObject> | null => {
+  const arrayIndexRegex = /[(\d)]/g;
+  const isIndexValue = destination.match(arrayIndexRegex);
 
-  const pickNames = (elements: UIElement<AnyObject>[]) => {
-    elements.forEach(element => {
-      if (element.name) {
-        elementNames.push(element.name);
-      }
+  const findByElementDefinitionByDestination = (
+    targetDestination: string,
+    elements: UIElement<AnyObject>[],
+  ): UIElement<AnyObject> | null => {
+    for (const element of elements) {
+      if (element.valueDestination === targetDestination) return element;
 
       if (element.elements) {
-        pickNames(element.elements);
+        const foundElement = findByElementDefinitionByDestination(
+          targetDestination,
+          element.elements,
+        );
+        if (foundElement) return foundElement;
       }
-    });
+    }
+
+    return null;
   };
 
-  pickNames(page.elements);
+  if (isIndexValue) {
+    const originArrayDestinationPath = destination.replace(
+      /\[(\d+)\]/,
+      `[${ARRAY_VALUE_INDEX_PLACEHOLDER}]`,
+    );
 
-  return elementNames;
+    const element = findByElementDefinitionByDestination(originArrayDestinationPath, page.elements);
+    return element;
+  }
+
+  return findByElementDefinitionByDestination(destination, page.elements);
 };


### PR DESCRIPTION
### Description
- Fixed bug where click on Continue didnt forced rendering of validation errors under fields in array-like forms (directors/ubos etc)

### Related issues
 * Provide a link to each related issue.

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings and errors
- [] New and existing tests pass locally with my changes
