### PR TITLE
Fixed cancel action on director blocks

### DIFF
--- a/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/hooks/useDirectorsBlocks/useDirectorsBlocks.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/hooks/useTasks/hooks/useDirectorsBlocks/useDirectorsBlocks.tsx
@@ -53,7 +53,7 @@ export const useDirectorsBlocks = (
     documentsToReset.forEach(document => {
       mutate({ documentId: document.id, contextUpdateMethod: 'director' });
     });
-  }, []);
+  }, [documents, mutate]);
 
   const blocks = useMemo(() => {
     return directors


### PR DESCRIPTION
### Description
Previously pressing on the X mark on "Re-upload needed" caused no re-render or visible change.
