### PR TITLE
feat: future & past dates can be disabled in date picker & ui bump

### DIFF
--- a/apps/backoffice-v2/CHANGELOG.md
+++ b/apps/backoffice-v2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ballerine/backoffice-v2
 
+## 0.5.38
+
+### Patch Changes
+
+- Updated dependencies
+  - @ballerine/ui@0.3.23
+
 ## 0.5.37
 
 ### Patch Changes

--- a/apps/backoffice-v2/package.json
+++ b/apps/backoffice-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerine/backoffice-v2",
-  "version": "0.5.37",
+  "version": "0.5.38",
   "description": "Ballerine - Backoffice",
   "homepage": "https://github.com/ballerine-io/ballerine",
   "repository": {
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@ballerine/common": "0.7.30",
-    "@ballerine/ui": "0.3.22",
+    "@ballerine/ui": "0.3.23",
     "@ballerine/workflow-browser-sdk": "0.5.30",
     "@ballerine/workflow-node-sdk": "0.5.30",
     "@fontsource/inter": "^4.5.15",

--- a/apps/kyb-app/CHANGELOG.md
+++ b/apps/kyb-app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # kyb-app
 
+## 0.1.33
+
+### Patch Changes
+
+- Updated dependencies
+  - @ballerine/ui@0.3.23
+
 ## 0.1.32
 
 ### Patch Changes

--- a/apps/kyb-app/package.json
+++ b/apps/kyb-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/kyb-app",
   "private": true,
-  "version": "0.1.32",
+  "version": "0.1.33",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -16,7 +16,7 @@
   "dependencies": {
     "@ballerine/blocks": "0.1.23",
     "@ballerine/common": "^0.7.30",
-    "@ballerine/ui": "0.3.22",
+    "@ballerine/ui": "0.3.23",
     "@ballerine/workflow-browser-sdk": "0.5.30",
     "@lukemorales/query-key-factory": "^1.0.3",
     "@radix-ui/react-icons": "^1.3.0",

--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/json-form.fields.ts
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/json-form.fields.ts
@@ -14,7 +14,7 @@ import {
   AutocompleteTextInputAdapter,
   baseLayouts,
   BooleanFieldAdapter,
-  DateInputAdater,
+  DateInputAdapter,
   FileInputAdapter,
   PhoneInputAdapter,
   TextInputAdapter,
@@ -27,7 +27,7 @@ export const jsonFormFields = {
 
   // Component with suffix Input is an extend of supported field types
   FileInput: withDynamicUIInput(FileInputAdapter),
-  DateInput: withDynamicUIInput(DateInputAdater),
+  DateInput: withDynamicUIInput(DateInputAdapter),
   PhoneInput: withDynamicUIInput(PhoneInputAdapter),
   AutocompleteInput: withDynamicUIInput(AutocompleteTextInputAdapter),
   DocumentInput: withDynamicUIInput(DocumentField),

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ballerine/ui
 
+## 0.3.23
+
+### Patch Changes
+
+- Exposed disableFuture & disablePast params from DatePicker & Added support of params to DatePickerAdapter
+
 ## 0.3.22
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/ui",
   "private": false,
-  "version": "0.3.22",
+  "version": "0.3.23",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/src/components/molecules/inputs/DatePickerInput/DatePickerInput.stories.tsx
+++ b/packages/ui/src/components/molecules/inputs/DatePickerInput/DatePickerInput.stories.tsx
@@ -32,3 +32,11 @@ const ControlledComponent = () => {
 export const Controlled = {
   render: ControlledComponent,
 };
+
+export const DisabledFutureDate = {
+  render: () => <DatePickerInput onChange={() => {}} params={{ disableFuture: true }} />,
+};
+
+export const DisabledPastDate = {
+  render: () => <DatePickerInput onChange={() => {}} params={{ disablePast: true }} />,
+};

--- a/packages/ui/src/components/molecules/inputs/DatePickerInput/DatePickerInput.tsx
+++ b/packages/ui/src/components/molecules/inputs/DatePickerInput/DatePickerInput.tsx
@@ -1,7 +1,7 @@
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { FocusEvent, useCallback, useMemo, useState } from 'react';
+import { FocusEvent, FunctionComponent, useCallback, useMemo, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
 import { TextField, TextFieldProps, ThemeProvider } from '@mui/material';
 import { muiTheme } from '@/common/mui-theme';
@@ -17,10 +17,16 @@ export interface DatePickerChangeEvent {
 
 export type DatePickerValue = number | string | Date | null;
 
+export interface DatePickerParams {
+  disableFuture?: boolean;
+  disablePast?: boolean;
+}
+
 export interface DatePickerProps {
   value?: DatePickerValue;
   name?: string;
   disabled?: boolean;
+  params?: DatePickerParams;
   onChange: (event: DatePickerChangeEvent) => void;
   onBlur?: (event: FocusEvent<any>) => void;
 }
@@ -29,6 +35,7 @@ export const DatePickerInput = ({
   value: _value,
   name,
   disabled = false,
+  params,
   onChange,
   onBlur,
 }: DatePickerProps) => {
@@ -69,8 +76,8 @@ export const DatePickerInput = ({
     return deserializeValue(_value);
   }, [_value, deserializeValue]);
 
-  const Field = useMemo(
-    () => (props: TextFieldProps) => {
+  const Field = useMemo(() => {
+    const Component: FunctionComponent<TextFieldProps> = props => {
       return (
         <TextField
           {...props}
@@ -107,14 +114,16 @@ export const DatePickerInput = ({
           }}
         />
       );
-    },
-    [isFocused],
-  );
+    };
+
+    return Component;
+  }, [isFocused]);
 
   return (
     <ThemeProvider theme={muiTheme}>
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <DatePicker
+          {...params}
           disabled={disabled}
           value={value}
           onChange={handleChange}

--- a/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/DateInputAdapter/DateInputAdapter.tsx
+++ b/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/DateInputAdapter/DateInputAdapter.tsx
@@ -9,7 +9,7 @@ export const isValidDate = (dateString: string): boolean => {
   return true;
 };
 
-export const DateInputAdater: RJSFInputAdapter<string | null> = ({
+export const DateInputAdapter: RJSFInputAdapter<string | null> = ({
   id,
   formData,
   disabled,
@@ -37,14 +37,13 @@ export const DateInputAdater: RJSFInputAdapter<string | null> = ({
     [onChange],
   );
 
-  const datePickerParams = useMemo(() => {
-    const params: DatePickerParams = {
+  const datePickerParams: DatePickerParams = useMemo(
+    () => ({
       disableFuture: uiSchema?.disableFutureDate,
       disablePast: uiSchema?.disablePastDate,
-    };
-
-    return params;
-  }, [uiSchema?.disableFutureDate, uiSchema?.disablePastDate]);
+    }),
+    [uiSchema?.disableFutureDate, uiSchema?.disablePastDate],
+  );
 
   return (
     <DatePickerInput

--- a/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/DateInputAdapter/index.ts
+++ b/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/DateInputAdapter/index.ts
@@ -1,0 +1,1 @@
+export * from './DateInputAdapter';

--- a/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/DateInputAdater/DateInputAdater.tsx
+++ b/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/DateInputAdater/DateInputAdater.tsx
@@ -1,6 +1,6 @@
-import { DatePickerChangeEvent, DatePickerInput } from '@/components/molecules';
+import { DatePickerChangeEvent, DatePickerInput, DatePickerParams } from '@/components/molecules';
 import { RJSFInputAdapter } from '@/components/organisms/DynamicForm/components/RSJVInputAdaters/types';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 export const isValidDate = (dateString: string): boolean => {
   const date = new Date(dateString);
@@ -13,6 +13,7 @@ export const DateInputAdater: RJSFInputAdapter<string | null> = ({
   id,
   formData,
   disabled,
+  uiSchema,
   onBlur,
   onChange,
 }) => {
@@ -36,9 +37,19 @@ export const DateInputAdater: RJSFInputAdapter<string | null> = ({
     [onChange],
   );
 
+  const datePickerParams = useMemo(() => {
+    const params: DatePickerParams = {
+      disableFuture: uiSchema?.disableFutureDate,
+      disablePast: uiSchema?.disablePastDate,
+    };
+
+    return params;
+  }, [uiSchema?.disableFutureDate, uiSchema?.disablePastDate]);
+
   return (
     <DatePickerInput
       value={formData ? formData : undefined}
+      params={datePickerParams}
       onChange={handleChange}
       disabled={disabled}
       onBlur={handleBlur}

--- a/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/DateInputAdater/index.ts
+++ b/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/DateInputAdater/index.ts
@@ -1,1 +1,0 @@
-export * from './DateInputAdater';

--- a/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/index.ts
+++ b/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/index.ts
@@ -1,6 +1,6 @@
 export * from './AutocompleteTextInputAdapter';
 export * from './BooleanFieldAdapter';
-export * from './DateInputAdater';
+export * from './DateInputAdapter';
 export * from './FileInputAdapter';
 export * from './PhoneInputAdapter';
 export * from './TextInputAdapter';

--- a/packages/ui/src/components/organisms/DynamicForm/fields.tsx
+++ b/packages/ui/src/components/organisms/DynamicForm/fields.tsx
@@ -1,7 +1,7 @@
 import { MultiselectInputAdapter } from '@/components/organisms/DynamicForm/components/RSJVInputAdaters';
 import { AutocompleteTextInputAdapter } from '@/components/organisms/DynamicForm/components/RSJVInputAdaters/AutocompleteTextInputAdapter';
 import { BooleanFieldAdapter } from '@/components/organisms/DynamicForm/components/RSJVInputAdaters/BooleanFieldAdapter';
-import { DateInputAdater } from '@/components/organisms/DynamicForm/components/RSJVInputAdaters/DateInputAdater';
+import { DateInputAdapter } from '@/components/organisms/DynamicForm/components/RSJVInputAdaters/DateInputAdapter';
 import { FileInputAdapter } from '@/components/organisms/DynamicForm/components/RSJVInputAdaters/FileInputAdapter';
 import { PhoneInputAdapter } from '@/components/organisms/DynamicForm/components/RSJVInputAdaters/PhoneInputAdapter';
 import { TextInputAdapter } from '@/components/organisms/DynamicForm/components/RSJVInputAdaters/TextInputAdapter';
@@ -24,7 +24,7 @@ export const fields: Record<
 
   // Component with suffix Input is an extend of supported field types
   FileInput: FileInputAdapter,
-  DateInput: DateInputAdater,
+  DateInput: DateInputAdapter,
   PhoneInput: PhoneInputAdapter,
   AutocompleteInput: AutocompleteTextInputAdapter,
   Multiselect: MultiselectInputAdapter,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         specifier: 0.7.30
         version: 0.7.30
       '@ballerine/ui':
-        specifier: 0.3.22
+        specifier: 0.3.23
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
         specifier: 0.5.30
@@ -365,7 +365,7 @@ importers:
         specifier: ^0.7.30
         version: link:../../packages/common
       '@ballerine/ui':
-        specifier: 0.3.22
+        specifier: 0.3.23
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
         specifier: 0.5.30


### PR DESCRIPTION
### Description
- Exposed params `disableFuture` & `disablePast` from `DatePicker`
- Updated DynamicForm adapter
- UI bump
- minor code refactoring

### Related issues
 * Provide a link to each related issue.

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings and errors
- [] New and existing tests pass locally with my changes
