### PR TITLE
Empty search querystring fix

### DIFF
--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -442,7 +442,7 @@ export class WorkflowService {
     const workflowIds = await this.workflowRuntimeDataRepository.search(
       {
         query: {
-          search,
+          search: search ?? '',
           entityType,
           statuses:
             ((query.where.status as Prisma.EnumWorkflowRuntimeDataStatusFilter)?.in as string[]) ||


### PR DESCRIPTION
### Description
Replaced `undeinfed` / `null` in search term value with empty string