### PR TITLE
feat: reworked exit from app for iframe scenarios

### DIFF
--- a/apps/kyb-app/src/App.tsx
+++ b/apps/kyb-app/src/App.tsx
@@ -1,4 +1,5 @@
 import { LoadingScreen } from '@/common/components/molecules/LoadingScreen';
+import { APP_LANGUAGE_QUERY_KEY } from '@/common/consts/consts';
 import { CustomerProviderFallback } from '@/components/molecules/CustomerProviderFallback';
 import { AppLoadingContainer } from '@/components/organisms/AppLoadingContainer';
 import { CustomerProvider } from '@/components/providers/CustomerProvider';
@@ -11,7 +12,7 @@ import * as Sentry from '@sentry/react';
 import { RouterProvider } from 'react-router-dom';
 
 export const App = () => {
-  const language = new URLSearchParams(window.location.search).get('lng') || 'en';
+  const language = new URLSearchParams(window.location.search).get(APP_LANGUAGE_QUERY_KEY) || 'en';
 
   const dependancyQueries = [
     useCustomerQuery(),

--- a/apps/kyb-app/src/App.tsx
+++ b/apps/kyb-app/src/App.tsx
@@ -12,6 +12,8 @@ import * as Sentry from '@sentry/react';
 import { RouterProvider } from 'react-router-dom';
 
 export const App = () => {
+  // useLanguage uses react-router context
+  // so it cannot be used here because this part is outside of Router context.
   const language = new URLSearchParams(window.location.search).get(APP_LANGUAGE_QUERY_KEY) || 'en';
 
   const dependancyQueries = [

--- a/apps/kyb-app/src/common/consts/consts.ts
+++ b/apps/kyb-app/src/common/consts/consts.ts
@@ -1,1 +1,2 @@
 export const ARRAY_VALUE_INDEX_PLACEHOLDER = `{INDEX}`;
+export const APP_LANGUAGE_QUERY_KEY = 'lng';

--- a/apps/kyb-app/src/components/layouts/AppShell/Navigation.tsx
+++ b/apps/kyb-app/src/components/layouts/AppShell/Navigation.tsx
@@ -6,7 +6,7 @@ import { usePageResolverContext } from '@/components/organisms/DynamicUI/PageRes
 import { useStateManagerContext } from '@/components/organisms/DynamicUI/StateManager/components/StateProvider';
 import { useDynamicUIContext } from '@/components/organisms/DynamicUI/hooks/useDynamicUIContext';
 import { useCustomer } from '@/components/providers/CustomerProvider';
-import { useFlowTracking } from '@/hooks/useFlowTracking';
+import { useAppExit } from '@/hooks/useAppExit/useAppExit';
 import { ctw } from '@ballerine/ui';
 
 export const Navigation = () => {
@@ -15,7 +15,7 @@ export const Navigation = () => {
   const { stateApi } = useStateManagerContext();
   const { currentPage } = usePageResolverContext();
   const { customer } = useCustomer();
-  const { trackExit } = useFlowTracking();
+  const exitFromApp = useAppExit();
 
   const isFirstStep = currentPage?.number === 1;
   const isDisabled = state.isLoading;
@@ -26,10 +26,9 @@ export const Navigation = () => {
       return;
     }
 
-    trackExit();
-    window.location.href = customer?.websiteUrl!;
+    exitFromApp();
     return;
-  }, [stateApi]);
+  }, [stateApi, exitFromApp]);
 
   return (
     <button

--- a/apps/kyb-app/src/domains/collection-flow/types/index.ts
+++ b/apps/kyb-app/src/domains/collection-flow/types/index.ts
@@ -131,9 +131,14 @@ export interface UIPage {
   pageValidation?: Rule[];
 }
 
+export interface UISchemaConfig {
+  kybOnExitAction?: 'send-event' | 'redirect-to-customer-portal';
+  supportedLanguages: string[];
+}
+
 export interface UISchema {
   id: string;
-  config: Record<string, unknown>;
+  config: UISchemaConfig;
   uiSchema: {
     elements: UIPage[];
   };

--- a/apps/kyb-app/src/hooks/useAppExit/useAppExit.ts
+++ b/apps/kyb-app/src/hooks/useAppExit/useAppExit.ts
@@ -10,7 +10,7 @@ export const useAppExit = () => {
   const { trackExit } = useFlowTracking();
   const { customer } = useCustomerQuery();
 
-  const { kybOnExitAction = 'send-event' } = uiSchema?.config || {};
+  const kybOnExitAction = uiSchema?.config?.kybOnExitAction || 'send-event';
 
   const exit = useCallback(() => {
     if (kybOnExitAction === 'send-event') {

--- a/apps/kyb-app/src/hooks/useAppExit/useAppExit.ts
+++ b/apps/kyb-app/src/hooks/useAppExit/useAppExit.ts
@@ -1,0 +1,29 @@
+import { useCustomerQuery } from '@/hooks/useCustomerQuery';
+import { useFlowTracking } from '@/hooks/useFlowTracking';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useUISchemasQuery } from '@/hooks/useUISchemasQuery';
+import { useCallback } from 'react';
+
+export const useAppExit = () => {
+  const appLanguage = useLanguage();
+  const { data: uiSchema } = useUISchemasQuery(appLanguage);
+  const { trackExit } = useFlowTracking();
+  const { customer } = useCustomerQuery();
+
+  const { kybOnExitAction = 'send-event' } = uiSchema?.config || {};
+
+  const exit = useCallback(() => {
+    if (kybOnExitAction === 'send-event') {
+      trackExit();
+      return;
+    }
+
+    if (kybOnExitAction === 'redirect-to-customer-portal') {
+      if (customer?.websiteUrl) {
+        location.href = customer?.websiteUrl;
+      }
+    }
+  }, [trackExit, customer]);
+
+  return exit;
+};

--- a/apps/kyb-app/src/hooks/useFlowTracking/useFlowTracking.ts
+++ b/apps/kyb-app/src/hooks/useFlowTracking/useFlowTracking.ts
@@ -2,10 +2,15 @@ import { useCallback } from 'react';
 
 export const useFlowTracking = () => {
   const trackExit = useCallback(() => {
-    window.parent.postMessage('ballerine.collection-flow.back-button-pressed', '*');
+    const event = 'ballerine.collection-flow.back-button-pressed';
+    console.log(`Sending event: ${event}`);
+    window.parent.postMessage(event, '*');
   }, []);
 
   const trackFinish = useCallback(() => {
+    const event = 'ballerine.collection-flow.finish-button-pressed';
+    console.log(`Sending event: ${event}`);
+
     window.parent.postMessage('ballerine.collection-flow.finish-button-pressed', '*');
   }, []);
 

--- a/apps/kyb-app/src/hooks/useLanguage/index.ts
+++ b/apps/kyb-app/src/hooks/useLanguage/index.ts
@@ -1,0 +1,1 @@
+export * from './useLanguage';

--- a/apps/kyb-app/src/hooks/useLanguage/useLanguage.ts
+++ b/apps/kyb-app/src/hooks/useLanguage/useLanguage.ts
@@ -1,0 +1,12 @@
+import { APP_LANGUAGE_QUERY_KEY } from '@/common/consts/consts';
+import { useSearchParams } from 'react-router-dom';
+
+const defaultQuery = {
+  lng: 'en',
+};
+
+export const useLanguage = () => {
+  const [location] = useSearchParams(defaultQuery);
+
+  return location.get(APP_LANGUAGE_QUERY_KEY) || defaultQuery.lng;
+};

--- a/apps/kyb-app/src/pages/CollectionFlow/CollectionFlow.tsx
+++ b/apps/kyb-app/src/pages/CollectionFlow/CollectionFlow.tsx
@@ -167,7 +167,7 @@ export const CollectionFlow = withSessionProtected(() => {
                           <AppShell.Sidebar>
                             <div className="flex h-full flex-col">
                               <div className="flex h-full flex-1 flex-col">
-                                <div className="flex flex-row justify-between whitespace-nowrap gap-2 pb-10">
+                                <div className="flex flex-row justify-between gap-2 whitespace-nowrap pb-10">
                                   <AppShell.Navigation />
                                   <div>
                                     <AppShell.LanguagePicker />

--- a/apps/kyb-app/src/pages/CollectionFlow/components/pages/Approved/Approved.tsx
+++ b/apps/kyb-app/src/pages/CollectionFlow/components/pages/Approved/Approved.tsx
@@ -29,7 +29,7 @@ export const Approved = withSessionProtected(() => {
             {t('approved.content', { companyName: customer?.displayName })}
           </p>
         </div>
-        {customer?.displayName && (
+        {customer && (
           <div className="flex justify-center">
             <Button variant="secondary" onClick={exitFromApp}>
               {t('backToPortal', { companyName: customer.displayName })}

--- a/apps/kyb-app/src/pages/CollectionFlow/components/pages/Approved/Approved.tsx
+++ b/apps/kyb-app/src/pages/CollectionFlow/components/pages/Approved/Approved.tsx
@@ -2,14 +2,14 @@ import DOMPurify from 'dompurify';
 import { useTranslation } from 'react-i18next';
 
 import { useCustomer } from '@/components/providers/CustomerProvider';
-import { useFlowTracking } from '@/hooks/useFlowTracking';
+import { useAppExit } from '@/hooks/useAppExit/useAppExit';
 import { withSessionProtected } from '@/hooks/useSessionQuery/hocs/withSessionProtected';
 import { Button, Card } from '@ballerine/ui';
 
 export const Approved = withSessionProtected(() => {
   const { t } = useTranslation();
   const { customer } = useCustomer();
-  const { trackExit } = useFlowTracking();
+  const exitFromApp = useAppExit();
 
   return (
     <div className="flex h-full items-center justify-center">
@@ -29,15 +29,9 @@ export const Approved = withSessionProtected(() => {
             {t('approved.content', { companyName: customer?.displayName })}
           </p>
         </div>
-        {customer?.displayName && customer?.websiteUrl && (
+        {customer?.displayName && (
           <div className="flex justify-center">
-            <Button
-              variant="secondary"
-              onClick={() => {
-                trackExit();
-                location.href = customer.websiteUrl;
-              }}
-            >
+            <Button variant="secondary" onClick={exitFromApp}>
               {t('backToPortal', { companyName: customer.displayName })}
             </Button>
           </div>

--- a/apps/kyb-app/src/pages/CollectionFlow/components/pages/Rejected/Rejected.tsx
+++ b/apps/kyb-app/src/pages/CollectionFlow/components/pages/Rejected/Rejected.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from 'react-i18next';
 
+import { useCustomer } from '@/components/providers/CustomerProvider';
 import { withSessionProtected } from '@/hooks/useSessionQuery/hocs/withSessionProtected';
 import { Card } from '@ballerine/ui';
-import { useCustomer } from '@/components/providers/CustomerProvider';
 
 export const Rejected = withSessionProtected(() => {
   const { t } = useTranslation();
@@ -20,7 +20,7 @@ export const Rejected = withSessionProtected(() => {
           <p className="text-muted-foreground text-center text-sm leading-5 opacity-50">
             {t('rejected.content')}
             <br />
-            {customer?.displayName && t('contact', { companyName: customer.displayName })}
+            {customer && t('contact', { companyName: customer.displayName })}
           </p>
         </div>
       </Card>

--- a/apps/kyb-app/src/pages/CollectionFlow/components/pages/Success/Success.tsx
+++ b/apps/kyb-app/src/pages/CollectionFlow/components/pages/Success/Success.tsx
@@ -2,7 +2,7 @@ import DOMPurify from 'dompurify';
 import { useTranslation } from 'react-i18next';
 
 import { useCustomer } from '@/components/providers/CustomerProvider';
-import { useFlowTracking } from '@/hooks/useFlowTracking';
+import { useAppExit } from '@/hooks/useAppExit/useAppExit';
 import { withSessionProtected } from '@/hooks/useSessionQuery/hocs/withSessionProtected';
 import { Button, Card } from '@ballerine/ui';
 
@@ -10,7 +10,7 @@ export const Success = withSessionProtected(() => {
   const { t } = useTranslation();
   const { customer } = useCustomer();
 
-  const { trackExit } = useFlowTracking();
+  const exitFromApp = useAppExit();
 
   return (
     <div className="flex h-full items-center justify-center">
@@ -29,15 +29,9 @@ export const Success = withSessionProtected(() => {
             {t('success.content')}
           </h2>
         </div>
-        {customer?.displayName && customer?.websiteUrl && (
+        {customer?.displayName && (
           <div className="flex justify-center">
-            <Button
-              variant="secondary"
-              onClick={() => {
-                trackExit();
-                location.href = customer.websiteUrl;
-              }}
-            >
+            <Button variant="secondary" onClick={exitFromApp}>
               {t('backToPortal', { companyName: customer.displayName })}
             </Button>
           </div>

--- a/services/workflows-service/src/workflow/schemas/zod-schemas.ts
+++ b/services/workflows-service/src/workflow/schemas/zod-schemas.ts
@@ -53,6 +53,7 @@ export const ConfigSchema = z
       .boolean()
       .optional()
       .describe('Indicates if workflow could be created in backoffice'),
+    kybOnExitAction: z.enum(['send-event', 'redirect-to-customer-portal']).optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## **User description**
### Description
- Enabled back button on approved/rejected screens even if customerUrl missing
- Exit strategy is now can be configured by workflow config with `config.kybOnExitAction = 'send-event' | 'redirect'`


___

## **Type**
enhancement


___

## **Description**
- Introduced `APP_LANGUAGE_QUERY_KEY` constant for consistent language query key usage across the app.
- Implemented a new exit strategy using `useAppExit` hook, allowing exit actions to be configured via `kybOnExitAction`.
- Enhanced event tracking with additional console logs for better debugging.
- Added `UISchemaConfig` interface to support new `kybOnExitAction` configuration.
- Adjusted exit logic in Navigation, Approved, and Success components to utilize the new exit strategy.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Use Constant for Language Query Key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/App.tsx
<li>Replaced direct query string parsing with <code>APP_LANGUAGE_QUERY_KEY</code> <br>constant for language setting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-484203e339161970a5e9ef03a8ce643847f48d4763c06b500bcc9dd0025d0776">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>consts.ts</strong><dd><code>Added Constant for Language Query Key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/common/consts/consts.ts
- Added `APP_LANGUAGE_QUERY_KEY` constant.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-b90cec805f2bb7487005324f6abf64a008f5ba0819b8bb705a2f9ff2b652eb9d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Navigation.tsx</strong><dd><code>Implement New Exit Strategy in Navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/components/layouts/AppShell/Navigation.tsx
<li>Replaced <code>useFlowTracking</code> hook with <code>useAppExit</code> for exit functionality.<br> <li> Adjusted exit logic to use <code>exitFromApp</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-333dd8acf8ec60e6855e9ade2ec3ad553e817ddf5b16c66c17a3bf6db9928438">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Extend UISchema with Exit Action Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/domains/collection-flow/types/index.ts
<li>Introduced <code>UISchemaConfig</code> interface with <code>kybOnExitAction</code> and <br><code>supportedLanguages</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-4b0c7eb0847168951ed5ea88596eb79d14e30241fa93e8b5be70c001d18a5140">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useAppExit.ts</strong><dd><code>New Hook for Handling App Exit Actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/hooks/useAppExit/useAppExit.ts
<li>Created <code>useAppExit</code> hook to handle exit actions based on <br><code>kybOnExitAction</code> config.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-333cad173d7467c064786bc1b79bb45f4025652f72fe19db4f49221c434086c3">+29/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useFlowTracking.ts</strong><dd><code>Enhance Event Tracking with Console Logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/hooks/useFlowTracking/useFlowTracking.ts
<li>Enhanced event tracking with console logs for exit and finish actions.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-087c3167e8076edd564359d5b3c31f635c3edb85be158a9d2663261caba1a891">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useLanguage.ts</strong><dd><code>New Hook for Language Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/hooks/useLanguage/useLanguage.ts
- Implemented `useLanguage` hook for managing app language setting.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-fe6aa003bba30dfa38a3c2f669d8ec2818eb0b3dcf4ace1ecd7f9587090d5f35">+12/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Approved.tsx</strong><dd><code>Use New Exit Strategy in Approved Page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/pages/CollectionFlow/components/pages/Approved/Approved.tsx
- Integrated `useAppExit` hook for exit action in Approved page.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-83876e85c0d26f5dfcba4eabf47e6e95b0241fce36cf5867e8495b6d6d0b9808">+4/-10</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Success.tsx</strong><dd><code>Use New Exit Strategy in Success Page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/pages/CollectionFlow/components/pages/Success/Success.tsx
- Integrated `useAppExit` hook for exit action in Success page.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-1705249fb55005028a9a6a2e2a2096c8d9052787ae0989e838b1d3e34f6ab0c9">+4/-10</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>zod-schemas.ts</strong><dd><code>Extend ConfigSchema with Exit Action Option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/src/workflow/schemas/zod-schemas.ts
<li>Added <code>kybOnExitAction</code> to <code>ConfigSchema</code> for workflow configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-6d086b12f0d4e85ae922a595183e3edc09ed17d4affe6ea4bf99b22fe9b3e506">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>CollectionFlow.tsx</strong><dd><code>Minor Formatting Adjustment in CollectionFlow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/pages/CollectionFlow/CollectionFlow.tsx
- Minor formatting adjustment in CollectionFlow component.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2095/files#diff-9f80dc062c628b3e45e8d210864e9563422b35691a22ffe9644d53145b724406">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
