### PR TITLE
Approve confirmation dialog

### DIFF
--- a/apps/backoffice-v2/src/common/components/molecules/Dialog/Dialog.tsx
+++ b/apps/backoffice-v2/src/common/components/molecules/Dialog/Dialog.tsx
@@ -11,12 +11,12 @@ import { AnimatePresence } from 'framer-motion';
 import { DialogClose } from '@radix-ui/react-dialog';
 
 export interface DialogProps extends ComponentProps<typeof ShadCNDialog> {
-  trigger: ReactNode | Array<ReactNode>;
-  content: ReactNode | Array<ReactNode>;
-  title?: ReactNode | Array<ReactNode>;
-  description?: ReactNode | Array<ReactNode>;
-  footer?: ReactNode | Array<ReactNode>;
-  close?: ReactNode | Array<ReactNode>;
+  trigger: ReactNode | ReactNode[];
+  content: ReactNode | ReactNode[];
+  title?: ReactNode | ReactNode[];
+  description?: ReactNode | ReactNode[];
+  footer?: ReactNode | ReactNode[];
+  close?: ReactNode | ReactNode[];
   props?: {
     dialog?: ComponentProps<typeof ShadCNDialog>;
     trigger?: ComponentProps<typeof DialogTrigger>;

--- a/apps/backoffice-v2/src/lib/blocks/components/KycBlock/hooks/useKycBlock/useKycBlock.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/components/KycBlock/hooks/useKycBlock/useKycBlock.tsx
@@ -18,9 +18,11 @@ import { useFilterId } from '@/common/hooks/useFilterId/useFilterId';
 import { useCaseDecision } from '@/pages/Entity/components/Case/hooks/useCaseDecision/useCaseDecision';
 import { ctw } from '@/common/utils/ctw/ctw';
 import { createBlocksTyped } from '@/lib/blocks/create-blocks-typed/create-blocks-typed';
-import { Badge } from '@ballerine/ui';
+import { Badge, Button } from '@ballerine/ui';
 import { WarningFilledSvg } from '@/common/components/atoms/icons';
 import { buttonVariants } from '@/common/components/atoms/Button/Button';
+import { MotionButton } from '@/common/components/molecules/MotionButton/MotionButton';
+import { motionButtonProps } from '@/lib/blocks/hooks/useAssosciatedCompaniesBlock/useAssociatedCompaniesBlock';
 
 const motionProps: ComponentProps<typeof MotionBadge> = {
   exit: { opacity: 0, transition: { duration: 0.2 } },
@@ -37,7 +39,7 @@ export const useKycBlock = ({
   parentWorkflowId: string;
 }) => {
   const { noAction } = useCaseDecision();
-  const results: Array<Array<string>> = [];
+  const results: string[][] = [];
   const kycSessionKeys = Object.keys(childWorkflow?.context?.pluginsOutput?.kyc_session ?? {});
 
   const docsData = useStorageFilesQuery(
@@ -674,14 +676,37 @@ export const useKycBlock = ({
         },
       })
       .addCell({
-        type: 'callToAction',
+        type: 'dialog',
         value: {
-          text: 'Approve',
-          onClick: onMutateApproveCase,
+          trigger: (
+            <MotionButton
+              {...motionButtonProps}
+              disabled={isDisabled}
+              size={'wide'}
+              variant={'success'}
+            >
+              Approve
+            </MotionButton>
+          ),
+          title: `Approval confirmation`,
+          description: <p className={`text-sm`}>Are you sure you want to approve?</p>,
+          close: (
+            <div className={`space-x-2`}>
+              <Button type={'button'} variant={`secondary`}>
+                Cancel
+              </Button>
+              <Button disabled={isDisabled} onClick={onMutateApproveCase}>
+                Approve
+              </Button>
+            </div>
+          ),
           props: {
-            disabled: isDisabled,
-            size: 'wide',
-            variant: 'success',
+            content: {
+              className: 'mb-96',
+            },
+            title: {
+              className: `text-2xl`,
+            },
           },
         },
       })

--- a/apps/backoffice-v2/src/lib/blocks/hooks/useDirectorsBlocks/useDirectorsBlocks.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/hooks/useDirectorsBlocks/useDirectorsBlocks.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { getDocumentsByCountry, StateTag, TDocument } from '@ballerine/common';
-import { ctw } from '@ballerine/ui';
+import { Button, ctw } from '@ballerine/ui';
 import { UseQueryResult } from '@tanstack/react-query';
 import {
   composePickableCategoryType,
@@ -22,6 +22,8 @@ import { getRevisionReasonsForDocument } from '@/lib/blocks/components/Directors
 import { valueOrNA } from '@/common/utils/value-or-na/value-or-na';
 import { toTitleCase } from 'string-ts';
 import { DecisionStatus, Director } from '@/lib/blocks/hooks/useDirectorsBlocks/types';
+import { MotionButton } from '@/common/components/molecules/MotionButton/MotionButton';
+import { motionButtonProps } from '@/lib/blocks/hooks/useAssosciatedCompaniesBlock/useAssociatedCompaniesBlock';
 
 export const useDirectorsBlocks = ({
   workflow,
@@ -239,20 +241,50 @@ export const useDirectorsBlocks = ({
               return approvedBadgeBlock;
             } else {
               if (decisionStatus !== 'revision') {
+                const isApproveDisabled =
+                  (!isDoneWithRevision && Boolean(document?.decision?.status)) ||
+                  noAction ||
+                  isLoadingApproveTaskById;
                 const approveButtonBlock = createBlocksTyped()
                   .addBlock()
                   .addCell({
-                    type: 'callToActionLegacy',
+                    type: 'dialog',
                     value: {
-                      text: 'Approve',
+                      trigger: (
+                        <MotionButton
+                          {...motionButtonProps}
+                          disabled={isApproveDisabled}
+                          size={'wide'}
+                          variant={'success'}
+                        >
+                          Approve
+                        </MotionButton>
+                      ),
+                      title: `Approval confirmation`,
+                      description: <p className={`text-sm`}>Are you sure you want to approve?</p>,
+                      close: (
+                        <div className={`space-x-2`}>
+                          <Button type={'button'} variant={`secondary`}>
+                            Cancel
+                          </Button>
+                          <Button
+                            disabled={isApproveDisabled}
+                            onClick={onMutateApproveTaskById({
+                              taskId: document.id,
+                              contextUpdateMethod: 'director',
+                            })}
+                          >
+                            Approve
+                          </Button>
+                        </div>
+                      ),
                       props: {
-                        decision: 'approve',
-                        id: document.id,
-                        contextUpdateMethod: 'director',
-                        disabled:
-                          (!isDoneWithRevision && Boolean(document?.decision?.status)) || noAction,
-                        workflow,
-                        onReuploadNeeded,
+                        content: {
+                          className: 'mb-96',
+                        },
+                        title: {
+                          className: `text-2xl`,
+                        },
                       },
                     },
                   })

--- a/apps/backoffice-v2/src/lib/blocks/hooks/useDocumentBlocks/useDocumentBlocks.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/hooks/useDocumentBlocks/useDocumentBlocks.tsx
@@ -27,6 +27,9 @@ import { useRejectTaskByIdMutation } from '@/domains/entities/hooks/mutations/us
 import { checkCanRevision } from '@/lib/blocks/hooks/useDocumentBlocks/utils/check-can-revision/check-can-revision';
 import { checkCanReject } from '@/lib/blocks/hooks/useDocumentBlocks/utils/check-can-reject/check-can-reject';
 import { checkCanApprove } from '@/lib/blocks/hooks/useDocumentBlocks/utils/check-can-approve/check-can-approve';
+import { MotionButton } from '@/common/components/molecules/MotionButton/MotionButton';
+import { motionButtonProps } from '@/lib/blocks/hooks/useAssosciatedCompaniesBlock/useAssociatedCompaniesBlock';
+import { Button } from '@ballerine/ui';
 
 export const useDocumentBlocks = ({
   workflow,
@@ -252,17 +255,43 @@ export const useDocumentBlocks = ({
               },
             })
             .addCell({
-              type: 'callToAction',
+              type: 'dialog',
               value: {
-                text: 'Approve',
-                onClick: onMutateApproveTaskById({
-                  taskId: id,
-                  contextUpdateMethod: 'base',
-                }),
+                trigger: (
+                  <MotionButton
+                    {...motionButtonProps}
+                    disabled={!canApprove}
+                    size={'wide'}
+                    variant={'success'}
+                  >
+                    Approve
+                  </MotionButton>
+                ),
+                title: `Approval confirmation`,
+                description: <p className={`text-sm`}>Are you sure you want to approve?</p>,
+                close: (
+                  <div className={`space-x-2`}>
+                    <Button type={'button'} variant={`secondary`}>
+                      Cancel
+                    </Button>
+                    <Button
+                      disabled={!canApprove}
+                      onClick={onMutateApproveTaskById({
+                        taskId: id,
+                        contextUpdateMethod: 'base',
+                      })}
+                    >
+                      Approve
+                    </Button>
+                  </div>
+                ),
                 props: {
-                  disabled: !canApprove,
-                  size: 'wide',
-                  variant: 'success',
+                  content: {
+                    className: 'mb-96',
+                  },
+                  title: {
+                    className: `text-2xl`,
+                  },
                 },
               },
             })

--- a/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useDefaultBlocksLogic/useDefaultBlocksLogic.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useDefaultBlocksLogic/useDefaultBlocksLogic.tsx
@@ -41,7 +41,6 @@ import {
   motionButtonProps,
   useAssociatedCompaniesBlock,
 } from '@/lib/blocks/hooks/useAssosciatedCompaniesBlock/useAssociatedCompaniesBlock';
-import { workflow as _workflow } from '../../../../../../pages/Entity/hooks/useEntityLogic/mock-workflow-with-children';
 
 const pluginsOutputBlacklist = [
   'companySanctions',
@@ -128,10 +127,7 @@ export const useDefaultBlocksLogic = () => {
     ...entityDataAdditionalInfo
   } = workflow?.context?.entity?.data?.additionalInfo ?? {};
   const { website: websiteBasicRequirement, processingDetails, ...storeInfo } = store ?? {};
-  const _kycChildWorkflows = workflow?.childWorkflows?.filter(
-    childWorkflow => childWorkflow?.context?.entity?.type === 'individual',
-  );
-  const kycChildWorkflows = _workflow?.childWorkflows?.filter(
+  const kycChildWorkflows = workflow?.childWorkflows?.filter(
     childWorkflow => childWorkflow?.context?.entity?.type === 'individual',
   );
   const kybChildWorkflows = workflow?.childWorkflows?.filter(

--- a/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useDefaultBlocksLogic/useDefaultBlocksLogic.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useDefaultBlocksLogic/useDefaultBlocksLogic.tsx
@@ -41,6 +41,7 @@ import {
   motionButtonProps,
   useAssociatedCompaniesBlock,
 } from '@/lib/blocks/hooks/useAssosciatedCompaniesBlock/useAssociatedCompaniesBlock';
+import { workflow as _workflow } from '../../../../../../pages/Entity/hooks/useEntityLogic/mock-workflow-with-children';
 
 const pluginsOutputBlacklist = [
   'companySanctions',
@@ -127,7 +128,10 @@ export const useDefaultBlocksLogic = () => {
     ...entityDataAdditionalInfo
   } = workflow?.context?.entity?.data?.additionalInfo ?? {};
   const { website: websiteBasicRequirement, processingDetails, ...storeInfo } = store ?? {};
-  const kycChildWorkflows = workflow?.childWorkflows?.filter(
+  const _kycChildWorkflows = workflow?.childWorkflows?.filter(
+    childWorkflow => childWorkflow?.context?.entity?.type === 'individual',
+  );
+  const kycChildWorkflows = _workflow?.childWorkflows?.filter(
     childWorkflow => childWorkflow?.context?.entity?.type === 'individual',
   );
   const kybChildWorkflows = workflow?.childWorkflows?.filter(


### PR DESCRIPTION
## **User description**
### Description
Changed the approve actions in the backoffice into a confirmation dialog.
![image](https://github.com/ballerine-io/ballerine/assets/61207713/d5507dbf-065f-4c41-8a64-5fbf3c8d6a3d)


___

## **Type**
enhancement


___

## **Description**
- Introduced a confirmation dialog for approval actions across various components using `MotionButton`.
- Simplified type definitions for `DialogProps` in Dialog component.
- Enhanced user experience by requiring confirmation before proceeding with approval actions, ensuring intentional user decisions.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dialog.tsx</strong><dd><code>Simplify DialogProps Type Definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backoffice-v2/src/common/components/molecules/Dialog/Dialog.tsx
- Simplified the type definitions for `DialogProps` properties.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2096/files#diff-f3f448cb6a0839d10ffe807d56c22f7652326decc50e30c5a0f65d2aa0abda89">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useKycBlock.tsx</strong><dd><code>Implement Approval Confirmation Dialog in KYC Block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backoffice-v2/src/lib/blocks/components/KycBlock/hooks/useKycBlock/useKycBlock.tsx
<li>Introduced <code>MotionButton</code> for the approve action within a confirmation <br>dialog.<br> <li> Changed the approve action to a dialog type with a confirmation step.<br> <li> Updated the results array type to a more concise syntax.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2096/files#diff-228217e3471e5da9a0eb2a1c7a54fd6e61adc2789fd66e3ca7de6824a5bfb0aa">+33/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useDirectorsBlocks.tsx</strong><dd><code>Add Approval Confirmation Dialog for Directors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backoffice-v2/src/lib/blocks/hooks/useDirectorsBlocks/useDirectorsBlocks.tsx
<li>Added <code>MotionButton</code> for the approve action within a confirmation <br>dialog.<br> <li> Changed the approve action to a dialog type with a confirmation step.<br> <li> Added logic to disable the approve button based on specific <br>conditions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2096/files#diff-ec76a87326a54ceae1b803b253fd4017749f90bb67e7f8a98d39891f40d5e6eb">+42/-10</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useDocumentBlocks.tsx</strong><dd><code>Implement Approval Confirmation Dialog in Document Blocks</code></dd></summary>
<hr>

apps/backoffice-v2/src/lib/blocks/hooks/useDocumentBlocks/useDocumentBlocks.tsx
<li>Introduced <code>MotionButton</code> for the approve action within a confirmation <br>dialog.<br> <li> Changed the approve action to a dialog type with a confirmation step.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2096/files#diff-d2f4da09a9e2a13fddeb51e7152c25d5f1da325ae578ed6c919155051d025008">+38/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
