### PR TITLE
fix: fixed bug where finish event was sent on continue clicks

### DIFF
--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/SubmitButton/SubmitButton.tsx
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/SubmitButton/SubmitButton.tsx
@@ -19,7 +19,7 @@ export const SubmitButton: UIElementComponent<{ text: string }> = ({ definition 
   const { onClickHandler } = useUIElementHandlers(definition);
   const { state } = useDynamicUIContext();
   const { state: uiElementState } = useUIElementState(definition);
-  const { currentPage } = usePageResolverContext();
+  const { currentPage, pages } = usePageResolverContext();
   const { errors } = usePageContext();
 
   const setPageElementsTouched = useCallback(
@@ -64,8 +64,13 @@ export const SubmitButton: UIElementComponent<{ text: string }> = ({ definition 
       state,
     );
     onClickHandler();
-    trackFinish();
-  }, [currentPage, state, setPageElementsTouched, onClickHandler, trackFinish]);
+
+    const isFinishPage = currentPage?.name === pages.at(-1)?.name;
+
+    if (isFinishPage) {
+      trackFinish();
+    }
+  }, [currentPage, pages, state, setPageElementsTouched, onClickHandler, trackFinish]);
 
   return (
     <Button


### PR DESCRIPTION
## **Type**
bug_fix, enhancement


___

## **Description**
- Fixed an issue where the finish event was incorrectly sent on every click of the continue button.
- Enhanced the `SubmitButton` component to only send the finish event when the user is on the last page, improving the accuracy of event tracking.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SubmitButton.tsx</strong><dd><code>Fix and Enhancement in SubmitButton Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/components/organisms/UIRenderer/elements/SubmitButton/SubmitButton.tsx
<li>Included <code>pages</code> variable in the destructuring of <br><code>usePageResolverContext</code>.<br> <li> Added logic to only track the finish event when the button is clicked <br>on the last page.


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2116/files#diff-cacd484ccbf3aee52e408bc1929b0f8edc516a593620a8ffe9abd1390b672e8d">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

