### PR TITLE
Add assignee to the document decision webhook

### DIFF
--- a/services/workflows-service/src/events/document-changed-webhook-caller.ts
+++ b/services/workflows-service/src/events/document-changed-webhook-caller.ts
@@ -177,6 +177,14 @@ export class DocumentChangedWebhookCaller {
         eventName: 'workflow.context.document.changed',
         apiVersion,
         timestamp: new Date().toISOString(),
+        assignee: data.assignee
+          ? {
+              id: data.assignee.id,
+              firstName: data.assignee.firstName,
+              lastName: data.assignee.lastName,
+              email: data.assignee.email,
+            }
+          : null,
         workflowCreatedAt: data.updatedRuntimeData.createdAt,
         workflowResolvedAt: data.updatedRuntimeData.resolvedAt,
         workflowDefinitionId: data.updatedRuntimeData.workflowDefinitionId,

--- a/services/workflows-service/src/workflow/types/index.ts
+++ b/services/workflows-service/src/workflow/types/index.ts
@@ -59,6 +59,7 @@ export interface IWorkflowContextChangedEventData {
   state: string | null;
   entityId: string;
   correlationId: string;
+  assignee: User | null;
 }
 
 export interface IWorkflowCompletedEventData {

--- a/services/workflows-service/src/workflow/workflow-runtime-data.repository.ts
+++ b/services/workflows-service/src/workflow/workflow-runtime-data.repository.ts
@@ -152,12 +152,19 @@ export class WorkflowRuntimeDataRepository {
 
   async updateStateById(
     id: string,
-    { data }: { data: Prisma.WorkflowRuntimeDataUncheckedUpdateInput },
+    {
+      data,
+      include = undefined,
+    }: {
+      data: Prisma.WorkflowRuntimeDataUncheckedUpdateInput;
+      include?: Prisma.WorkflowRuntimeDataInclude;
+    },
     transaction: PrismaTransaction,
-  ): Promise<WorkflowRuntimeData> {
+  ) {
     return await transaction.workflowRuntimeData.update({
       where: { id },
-      data: data,
+      data,
+      include,
     });
   }
 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added `assignee` information to the document changed webhook payload, allowing for more detailed event data.
- Introduced `assignee` field in `IWorkflowContextChangedEventData` interface to support this new data.
- Enhanced the `updateStateById` method in `WorkflowRuntimeDataRepository` to support inclusion of related entities, specifically `assignee`.
- Updated `WorkflowService` methods to include `assignee` information when emitting `workflow.context.changed` events and when fetching workflow runtime data.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>document-changed-webhook-caller.ts</strong><dd><code>Add Assignee Information to Webhook Payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/src/events/document-changed-webhook-caller.ts
<li>Added <code>assignee</code> information to the document changed webhook payload.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2150/files#diff-e0ce654a21f9ff4715f48e50d79d144b53c8661fa05e30372c287845cd7aa467">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Extend Event Data Interface with Assignee Field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/src/workflow/types/index.ts
<li>Introduced <code>assignee</code> field in <code>IWorkflowContextChangedEventData</code> <br>interface.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2150/files#diff-496c0b4e0e2b30f5b2572ff03ac1d041fa765395e860d42be83e66df9b1bd9c8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workflow-runtime-data.repository.ts</strong><dd><code>Enhance Update Method to Support Related Entities Inclusion</code></dd></summary>
<hr>

services/workflows-service/src/workflow/workflow-runtime-data.repository.ts
<li>Modified <code>updateStateById</code> method to accept <code>include</code> parameter.<br> <li> Enhanced method to include related entities based on the <code>include</code> <br>parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2150/files#diff-49e748774dccb6b761efb574fc4430dcc44ed90983f9a5eedaf4d205f408d7a3">+10/-3</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workflow.service.ts</strong><dd><code>Update Workflow Service to Include Assignee in Events</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/src/workflow/workflow.service.ts
<li>Updated <code>updateStateById</code> call to include <code>assignee</code> data.<br> <li> Emit <code>workflow.context.changed</code> event with <code>assignee</code> information.<br> <li> Adjusted method calls to include <code>assignee</code> information when fetching <br>runtime data.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2150/files#diff-0d7bfa115a67cf2b6f48d1ffed54baafb021c6e2e36f055069c0930cd336a904">+11/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

