### PR TITLE
fix: fixed bug where event was dispatched when form isnt valid

### DIFF
--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/SubmitButton/SubmitButton.tsx
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/SubmitButton/SubmitButton.tsx
@@ -12,7 +12,7 @@ import { UIElementComponent } from '@/components/organisms/UIRenderer/types';
 import { UIPage } from '@/domains/collection-flow';
 import { useFlowTracking } from '@/hooks/useFlowTracking';
 import { Button } from '@ballerine/ui';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 export const SubmitButton: UIElementComponent<{ text: string }> = ({ definition }) => {
   const { helpers } = useDynamicUIContext();
@@ -21,6 +21,7 @@ export const SubmitButton: UIElementComponent<{ text: string }> = ({ definition 
   const { state: uiElementState } = useUIElementState(definition);
   const { currentPage, pages } = usePageResolverContext();
   const { errors } = usePageContext();
+  const isValid = useMemo(() => !Object.values(errors).length, [errors]);
 
   const setPageElementsTouched = useCallback(
     (page: UIPage, state: UIState) => {
@@ -67,10 +68,10 @@ export const SubmitButton: UIElementComponent<{ text: string }> = ({ definition 
 
     const isFinishPage = currentPage?.name === pages.at(-1)?.name;
 
-    if (isFinishPage) {
+    if (isFinishPage && isValid) {
       trackFinish();
     }
-  }, [currentPage, pages, state, setPageElementsTouched, onClickHandler, trackFinish]);
+  }, [currentPage, pages, state, isValid, setPageElementsTouched, onClickHandler, trackFinish]);
 
   return (
     <Button


### PR DESCRIPTION
## **User description**
### Description
- fixed bug where event was dispatched when form isnt valid


___

## **Type**
bug_fix


___

## **Description**
- Added a validation check to ensure that an event is dispatched only if the form is valid. This is achieved by using `useMemo` to monitor form errors and adjusting the event dispatch condition accordingly.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SubmitButton.tsx</strong><dd><code>Prevent Event Dispatch on Invalid Form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/kyb-app/src/components/organisms/UIRenderer/elements/SubmitButton/SubmitButton.tsx
<li>Added <code>useMemo</code> to check if the form is valid based on errors.<br> <li> Modified the condition to dispatch the event only if the form is valid <br>on the finish page.


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2155/files#diff-cacd484ccbf3aee52e408bc1929b0f8edc516a593620a8ffe9abd1390b672e8d">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

