### PR TITLE
fix: fixed bug where case creation button been displayed on any case

### DIFF
--- a/apps/backoffice-v2/src/pages/Entities/components/CaseCreation/CaseCreation.tsx
+++ b/apps/backoffice-v2/src/pages/Entities/components/CaseCreation/CaseCreation.tsx
@@ -11,6 +11,8 @@ export const CaseCreation = withCaseCreation(() => {
   const { workflowDefinition, isLoading, error } = useCaseCreationWorkflowDefinition();
   const { isOpen, setIsOpen: setOpen } = useCaseCreationContext();
 
+  if (!workflowDefinition?.config?.enableManualCreation) return null;
+
   return (
     <Sheet open={isOpen} onOpenChange={setOpen}>
       <SheetTrigger asChild>


### PR DESCRIPTION
## **User description**
### Description
- fixed bug where case creation button been displayed on any case


___

## **Type**
bug_fix


___

## **Description**
- Added a conditional rendering logic to the Case Creation component to ensure it only renders when manual case creation is enabled. This fixes the bug where the case creation button was displayed regardless of the `enableManualCreation` flag state.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CaseCreation.tsx</strong><dd><code>Conditionally Render Case Creation Component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backoffice-v2/src/pages/Entities/components/CaseCreation/CaseCreation.tsx
<li>Added a condition to check <code>enableManualCreation</code> flag before rendering <br>the Case Creation component.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2163/files#diff-0571654683166a69377190d3a2cfb7815b4ee649b5446a4337d8d02c98161656">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

