### PR TITLE
Add `assignedAt` to the document decision webhook

### DIFF
--- a/services/workflows-service/src/events/document-changed-webhook-caller.ts
+++ b/services/workflows-service/src/events/document-changed-webhook-caller.ts
@@ -188,6 +188,7 @@ export class DocumentChangedWebhookCaller {
               email: data.assignee.email,
             }
           : null,
+        assignedAt: data.assignedAt,
         workflowCreatedAt: data.updatedRuntimeData.createdAt,
         workflowResolvedAt: data.updatedRuntimeData.resolvedAt,
         workflowDefinitionId: data.updatedRuntimeData.workflowDefinitionId,

--- a/services/workflows-service/src/workflow/types/index.ts
+++ b/services/workflows-service/src/workflow/types/index.ts
@@ -7,8 +7,8 @@ import {
   WorkflowDefinition,
   WorkflowRuntimeData,
   WorkflowRuntimeDataStatus,
+  User,
 } from '@prisma/client';
-import { User } from '@sentry/node';
 import type { TProjectIds } from '@/types';
 
 export interface RunnableWorkflowData {
@@ -60,6 +60,7 @@ export interface IWorkflowContextChangedEventData {
   entityId: string;
   correlationId: string;
   assignee: User | null;
+  assignedAt: Date | null;
 }
 
 export interface IWorkflowCompletedEventData {

--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -1154,6 +1154,7 @@ export class WorkflowService {
       if (contextHasChanged) {
         this.workflowEventEmitter.emit('workflow.context.changed', {
           assignee: updatedResult.assignee,
+          assignedAt: updatedResult.assignedAt,
           oldRuntimeData: runtimeData,
           updatedRuntimeData: updatedResult,
           state: currentState as string,
@@ -2183,6 +2184,7 @@ export class WorkflowService {
       systemEventName,
       {
         assignee: runtimeData.assignee,
+        assignedAt: runtimeData.assignedAt,
         oldRuntimeData: runtimeData,
         updatedRuntimeData: runtimeData,
         state: runtimeData.state as string,


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added `assignedAt` field to the document changed webhook payload, allowing consumers to know when a document was assigned.
- Refactored the import of the `User` model to use `@prisma/client` for consistency across the service.
- Enhanced event data interfaces and service event emissions to include the `assignedAt` field, providing more detailed context for workflow changes.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>document-changed-webhook-caller.ts</strong><dd><code>Add `assignedAt` to Document Changed Webhook Payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/src/events/document-changed-webhook-caller.ts
- Added `assignedAt` to the payload of the document changed webhook.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2172/files#diff-e0ce654a21f9ff4715f48e50d79d144b53c8661fa05e30372c287845cd7aa467">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Refactor User Import and Extend Event Data Interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/src/workflow/types/index.ts
<li>Imported <code>User</code> from <code>@prisma/client</code> instead of <code>@sentry/node</code>.<br> <li> Added <code>assignedAt</code> field to <code>IWorkflowContextChangedEventData</code> interface.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2172/files#diff-496c0b4e0e2b30f5b2572ff03ac1d041fa765395e860d42be83e66df9b1bd9c8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workflow.service.ts</strong><dd><code>Include `assignedAt` in Workflow Service Event Emissions</code>&nbsp; </dd></summary>
<hr>

services/workflows-service/src/workflow/workflow.service.ts
<li>Included <code>assignedAt</code> in the event data for <code>workflow.context.changed</code> and <br>system events.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2172/files#diff-0d7bfa115a67cf2b6f48d1ffed54baafb021c6e2e36f055069c0930cd336a904">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

