### PR TITLE
bug/invoked-at-issue

### DIFF
--- a/packages/workflow-core/src/lib/plugins/external-plugin/api-plugin.ts
+++ b/packages/workflow-core/src/lib/plugins/external-plugin/api-plugin.ts
@@ -83,16 +83,14 @@ export class ApiPlugin {
           return this.returnErrorResponse(errorMessage!);
         }
 
-        const invokedAt = Date.now();
 
         if (this.successAction) {
           return this.returnSuccessResponse(this.successAction, {
             ...responseBody,
-            invokedAt,
           });
         }
 
-        return { invokedAt };
+        return { };
       } else {
         const errorResponse = await apiResponse.json();
 

--- a/packages/workflow-core/src/lib/plugins/external-plugin/webhook-plugin.ts
+++ b/packages/workflow-core/src/lib/plugins/external-plugin/webhook-plugin.ts
@@ -19,6 +19,6 @@ export class WebhookPlugin extends ApiPlugin {
       console.error(err);
     }
 
-    return { invokedAt: Date.now() };
+    return { };
   }
 }

--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -286,7 +286,7 @@ export class WorkflowService {
         pluginsOutput: Object.fromEntries(
           Object.entries(workflow.context.pluginsOutput || {}).map(([pluginName, pluginValue]) => {
             if (isObject(pluginValue) && pluginValue.status === ProcessStatus.IN_PROGRESS) {
-              const parsedDate = new Date(pluginValue.invokedAt);
+              const parsedDate = new Date(Number(pluginValue.invokedAt));
 
               const TIMEOUT_IN_MS = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## **User description**
fix(kyc): fix response for resubmittion result & map resubmittion to declined

### Description
Elaborate on the subject, motivation, and context.

### Related issues
 * Provide a link to each related issue.

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings and errors
- [] New and existing tests pass locally with my changes


___

## **Type**
bug_fix


___

## **Description**
- Removed the `invokedAt` timestamp from API and webhook plugin responses to simplify the response structure.
- Fixed the parsing of `invokedAt` in the workflow service to correctly handle the timestamp as a number.
- Updated the data migrations submodule to the latest commit.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api-plugin.ts</strong><dd><code>Simplify API Plugin Response Structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/workflow-core/src/lib/plugins/external-plugin/api-plugin.ts
<li>Removed the <code>invokedAt</code> timestamp from the success response and error <br>handling paths.<br> <li> Simplified the return object in the main conditional block by removing <br>unnecessary properties.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2196/files#diff-ff1ae21f4192aaa50415159baf2f54727da9d5845efac07bfcb3cfbda7717dc6">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>webhook-plugin.ts</strong><dd><code>Remove Timestamp from Webhook Plugin Response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/workflow-core/src/lib/plugins/external-plugin/webhook-plugin.ts
<li>Removed the <code>invokedAt</code> timestamp from the return object in the webhook <br>plugin.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2196/files#diff-aac0a0e450a3814ef4a76d3a9a104dba5034acc628cd09bee0e4e3e7b1751865">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workflow.service.ts</strong><dd><code>Fix Date Parsing in Workflow Service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/src/workflow/workflow.service.ts
<li>Adjusted the parsing of <code>invokedAt</code> to ensure it's treated as a number <br>before converting to a Date object.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2196/files#diff-0d7bfa115a67cf2b6f48d1ffed54baafb021c6e2e36f055069c0930cd336a904">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data-migrations</strong><dd><code>Update Data Migrations Submodule Pointer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/prisma/data-migrations
- Updated the submodule pointer for data migrations.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2196/files#diff-9c33eef7eba3ba7ca6006881973adb35d0cbc4048bb7256f945ab6da6f013edf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

