### PR TITLE
bug/plugins-output-invoked-at

### DIFF
--- a/packages/workflow-core/src/lib/plugins/external-plugin/api-plugin.test.ts
+++ b/packages/workflow-core/src/lib/plugins/external-plugin/api-plugin.test.ts
@@ -79,7 +79,6 @@ describe('workflow-runner', () => {
           ).pluginsOutput,
         ).toEqual({
           ballerineEnrichment: {
-            invokedAt: expect.any(Number),
             result: {
               companyInfo: {
                 companyName: 'TestCorp Ltd',

--- a/packages/workflow-core/src/lib/plugins/external-plugin/api-plugin.ts
+++ b/packages/workflow-core/src/lib/plugins/external-plugin/api-plugin.ts
@@ -83,16 +83,13 @@ export class ApiPlugin {
           return this.returnErrorResponse(errorMessage!);
         }
 
-        const invokedAt = Date.now();
-
         if (this.successAction) {
           return this.returnSuccessResponse(this.successAction, {
             ...responseBody,
-            invokedAt,
           });
         }
 
-        return { invokedAt };
+        return {};
       } else {
         const errorResponse = await apiResponse.json();
 

--- a/packages/workflow-core/src/lib/plugins/external-plugin/webhook-plugin.ts
+++ b/packages/workflow-core/src/lib/plugins/external-plugin/webhook-plugin.ts
@@ -19,6 +19,6 @@ export class WebhookPlugin extends ApiPlugin {
       console.error(err);
     }
 
-    return { invokedAt: Date.now() };
+    return {};
   }
 }

--- a/services/workflows-service/src/workflow/workflow.service.ts
+++ b/services/workflows-service/src/workflow/workflow.service.ts
@@ -285,8 +285,12 @@ export class WorkflowService {
         ),
         pluginsOutput: Object.fromEntries(
           Object.entries(workflow.context.pluginsOutput || {}).map(([pluginName, pluginValue]) => {
-            if (isObject(pluginValue) && pluginValue.status === ProcessStatus.IN_PROGRESS) {
-              const parsedDate = new Date(pluginValue.invokedAt);
+            if (
+              isObject(pluginValue) &&
+              pluginValue.status === ProcessStatus.IN_PROGRESS &&
+              pluginValue.invokedAt
+            ) {
+              const parsedDate = new Date(Number(pluginValue.invokedAt));
 
               const TIMEOUT_IN_MS = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
## **User description**
fix: removed hardcoded invoked at from plugins


___

## **Type**
bug_fix


___

## **Description**
- Removed hardcoded `invokedAt` timestamp from the success response in both `ApiPlugin` and `WebhookPlugin`.
- Simplified the return object in `ApiPlugin` by excluding `invokedAt`.
- Updated the submodule reference for data migrations to reflect the latest changes.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api-plugin.ts</strong><dd><code>Remove Hardcoded `invokedAt` from API Plugin Responses</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/workflow-core/src/lib/plugins/external-plugin/api-plugin.ts
<li>Removed hardcoded <code>invokedAt</code> from success response in <code>ApiPlugin</code>.<br> <li> Simplified the return object in the main function by removing <br><code>invokedAt</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2197/files#diff-ff1ae21f4192aaa50415159baf2f54727da9d5845efac07bfcb3cfbda7717dc6">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>webhook-plugin.ts</strong><dd><code>Remove Hardcoded `invokedAt` from Webhook Plugin Response</code></dd></summary>
<hr>

packages/workflow-core/src/lib/plugins/external-plugin/webhook-plugin.ts
<li>Removed hardcoded <code>invokedAt</code> from the return object in <code>WebhookPlugin</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2197/files#diff-aac0a0e450a3814ef4a76d3a9a104dba5034acc628cd09bee0e4e3e7b1751865">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data-migrations</strong><dd><code>Update Data Migrations Submodule Reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/prisma/data-migrations
- Updated submodule reference for data migrations.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2197/files#diff-9c33eef7eba3ba7ca6006881973adb35d0cbc4048bb7256f945ab6da6f013edf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

