### PR TITLE
Added display name for workflow definition

### DIFF
--- a/apps/backoffice-v2/src/domains/workflow-definitions/fetchers.ts
+++ b/apps/backoffice-v2/src/domains/workflow-definitions/fetchers.ts
@@ -25,6 +25,7 @@ export const WorkflowDefinitionConfigSchema = z
 
 export const WorkflowDefinitionByIdSchema = ObjectWithIdSchema.extend({
   name: z.string(),
+  displayName: z.string().nullable(),
   version: z.number(),
   variant: z.string().default(WorkflowDefinitionVariant.DEFAULT),
   contextSchema: z.record(z.any(), z.any()).nullable(),

--- a/apps/backoffice-v2/src/pages/Entities/Entities.page.tsx
+++ b/apps/backoffice-v2/src/pages/Entities/Entities.page.tsx
@@ -24,7 +24,7 @@ export const Entities: FunctionComponent = () => {
     totalPages,
     caseCount,
     skeletonEntities,
-    showCaseCreation,
+    isManualCaseCreationEnabled,
   } = useEntities();
 
   return (
@@ -39,8 +39,8 @@ export const Entities: FunctionComponent = () => {
       >
         <MotionScrollArea
           className={ctw({
-            'h-[calc(100vh-300px)]': showCaseCreation,
-            'h-[calc(100vh-240px)]': !showCaseCreation,
+            'h-[calc(100vh-300px)]': isManualCaseCreationEnabled,
+            'h-[calc(100vh-240px)]': !isManualCaseCreationEnabled,
           })}
         >
           <Cases.List>
@@ -72,7 +72,7 @@ export const Entities: FunctionComponent = () => {
         <div className={`divider my-0 px-4`}></div>
         <div className="flex flex-col gap-5 px-4">
           <Pagination onPaginate={onPaginate} page={page} totalPages={totalPages} />
-          <CaseCreation />
+          {isManualCaseCreationEnabled && <CaseCreation />}
         </div>
       </Cases>
       {/* Display skeleton individual when loading the entities list */}

--- a/apps/backoffice-v2/src/pages/Entities/components/CaseCreation/CaseCreation.tsx
+++ b/apps/backoffice-v2/src/pages/Entities/components/CaseCreation/CaseCreation.tsx
@@ -8,10 +8,13 @@ import { useCaseCreationWorkflowDefinition } from '@/pages/Entities/components/C
 import { Plus } from 'lucide-react';
 import { valueOrNA } from '@/common/utils/value-or-na/value-or-na';
 import { ctw } from '@/common/utils/ctw/ctw';
+import { titleCase } from 'string-ts';
 
 export const CaseCreation = withCaseCreation(() => {
   const { workflowDefinition, isLoading, error } = useCaseCreationWorkflowDefinition();
   const { isOpen, setIsOpen: setOpen } = useCaseCreationContext();
+  const workflowDefinitionName =
+    workflowDefinition?.displayName || titleCase(workflowDefinition?.name ?? '');
 
   return (
     <Sheet open={isOpen} onOpenChange={setOpen}>
@@ -31,20 +34,20 @@ export const CaseCreation = withCaseCreation(() => {
             <div className="flex flex-col">
               <span
                 className={ctw('pb-3 text-base font-bold capitalize', {
-                  'text-slate-400': !workflowDefinition?.displayName,
+                  'text-slate-400': !workflowDefinitionName,
                 })}
               >
-                {valueOrNA(workflowDefinition?.displayName)}
+                {valueOrNA(workflowDefinitionName)}
               </span>
               <h1 className="leading-0 pb-5 text-3xl font-bold">Add a Case</h1>
               <p className="pb-10">
                 Create a{' '}
                 <span
                   className={ctw({
-                    'text-slate-400': !workflowDefinition?.displayName,
+                    'text-slate-400': !workflowDefinitionName,
                   })}
                 >
-                  {valueOrNA(workflowDefinition?.displayName)}
+                  {valueOrNA(workflowDefinitionName)}
                 </span>{' '}
                 case by filling in the information below. Please ensure all the required fields are
                 filled out correctly.

--- a/apps/backoffice-v2/src/pages/Entities/components/CaseCreation/CaseCreation.tsx
+++ b/apps/backoffice-v2/src/pages/Entities/components/CaseCreation/CaseCreation.tsx
@@ -6,12 +6,12 @@ import { withCaseCreation } from '@/pages/Entities/components/CaseCreation/conte
 import { useCaseCreationContext } from '@/pages/Entities/components/CaseCreation/context/case-creation-context/hooks/useCaseCreationContext';
 import { useCaseCreationWorkflowDefinition } from '@/pages/Entities/components/CaseCreation/hooks/useCaseCreationWorkflowDefinition';
 import { Plus } from 'lucide-react';
+import { valueOrNA } from '@/common/utils/value-or-na/value-or-na';
+import { ctw } from '@/common/utils/ctw/ctw';
 
 export const CaseCreation = withCaseCreation(() => {
   const { workflowDefinition, isLoading, error } = useCaseCreationWorkflowDefinition();
   const { isOpen, setIsOpen: setOpen } = useCaseCreationContext();
-
-  if (!workflowDefinition?.config?.enableManualCreation) return null;
 
   return (
     <Sheet open={isOpen} onOpenChange={setOpen}>
@@ -29,13 +29,25 @@ export const CaseCreation = withCaseCreation(() => {
         {!isLoading && workflowDefinition ? (
           <div className="flex flex-col px-[60px] py-[72px]">
             <div className="flex flex-col">
-              <span className="pb-3 text-base font-bold capitalize">
-                {workflowDefinition?.name?.replaceAll('_', ' ')}
+              <span
+                className={ctw('pb-3 text-base font-bold capitalize', {
+                  'text-slate-400': !workflowDefinition?.displayName,
+                })}
+              >
+                {valueOrNA(workflowDefinition?.displayName)}
               </span>
               <h1 className="leading-0 pb-5 text-3xl font-bold">Add a Case</h1>
               <p className="pb-10">
-                Create a {workflowDefinition?.name} case by filling in the information below. Please
-                ensure all the required fields are filled out correctly.
+                Create a{' '}
+                <span
+                  className={ctw({
+                    'text-slate-400': !workflowDefinition?.displayName,
+                  })}
+                >
+                  {valueOrNA(workflowDefinition?.displayName)}
+                </span>{' '}
+                case by filling in the information below. Please ensure all the required fields are
+                filled out correctly.
               </p>
               <div className="flex flex-col gap-6">
                 <h2 className="fontbold text-2xl">Case information</h2>

--- a/apps/backoffice-v2/src/pages/Entities/hooks/useEntities/useEntities.tsx
+++ b/apps/backoffice-v2/src/pages/Entities/hooks/useEntities/useEntities.tsx
@@ -97,7 +97,6 @@ export const useEntities = () => {
     onFilter: onFilterChange,
     onSortBy: onSortByChange,
     onSortDirToggle,
-    showCaseCreation: workflowDefinition?.config?.enableManualCreation,
     search: searchValue,
     cases: data?.data,
     caseCount: data?.meta?.totalItems || 0,
@@ -106,5 +105,6 @@ export const useEntities = () => {
     totalPages,
     skeletonEntities,
     entity,
+    isManualCaseCreationEnabled: workflowDefinition?.config?.enableManualCreation,
   };
 };

--- a/services/workflows-service/prisma/migrations/20240314123948_definition_display_name/migration.sql
+++ b/services/workflows-service/prisma/migrations/20240314123948_definition_display_name/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "WorkflowDefinition" ADD COLUMN     "displayName" TEXT;

--- a/services/workflows-service/prisma/schema.prisma
+++ b/services/workflows-service/prisma/schema.prisma
@@ -146,6 +146,7 @@ model Business {
 
 model WorkflowDefinition {
   id              String  @id @default(cuid())
+  displayName     String?
   reviewMachineId String?
   name            String
   version         Int     @default(1)


### PR DESCRIPTION
## **User description**
- refactor(backoffice-v2): changed case creation to use displayName over name
- refactor(backoffice-v2): changed fallback of display name

### Description
Elaborate on the subject, motivation, and context.

### Related issues
 * Provide a link to each related issue.

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings and errors
- [] New and existing tests pass locally with my changes


___

## **Type**
enhancement


___

## **Description**
- Added `displayName` field to `WorkflowDefinitionByIdSchema` to support more user-friendly names in the UI.
- Refactored case creation toggle and rendering logic in the Entities page, replacing `showCaseCreation` with `isManualCaseCreationEnabled`.
- Enhanced the display of workflow definition names in the Case Creation component, using `displayName` or a formatted `name` as a fallback.
- Updated the `useEntities` hook to use `isManualCaseCreationEnabled` for better clarity and control over case creation feature.
- Included a database migration to add a `displayName` column to the `WorkflowDefinition` table.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fetchers.ts</strong><dd><code>Add displayName Field to Workflow Definition Schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backoffice-v2/src/domains/workflow-definitions/fetchers.ts
- Added `displayName` field to `WorkflowDefinitionByIdSchema`.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2205/files#diff-2731b123311c24beda78b711ce29241d97755dac7b8ceb60d83b6f9c44b37e7f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Entities.page.tsx</strong><dd><code>Refactor Case Creation Toggle and Rendering Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backoffice-v2/src/pages/Entities/Entities.page.tsx
<li>Renamed <code>showCaseCreation</code> to <code>isManualCaseCreationEnabled</code>.<br> <li> Conditionally render <code>CaseCreation</code> based on <br><code>isManualCaseCreationEnabled</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2205/files#diff-384486366c1cdb1d56797b91c88188872f61fda534543a5c238752d3ea9a9dcf">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CaseCreation.tsx</strong><dd><code>Enhance Workflow Definition Name Display in Case Creation</code></dd></summary>
<hr>

apps/backoffice-v2/src/pages/Entities/components/CaseCreation/CaseCreation.tsx
<li>Utilize <code>displayName</code> or fallback to formatted <code>name</code> for workflow <br>definition.<br> <li> Improved text display with conditional styling for missing names.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2205/files#diff-0571654683166a69377190d3a2cfb7815b4ee649b5446a4337d8d02c98161656">+21/-6</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useEntities.tsx</strong><dd><code>Refactor Entities Hook to Use isManualCaseCreationEnabled</code></dd></summary>
<hr>

apps/backoffice-v2/src/pages/Entities/hooks/useEntities/useEntities.tsx
<li>Removed <code>showCaseCreation</code>.<br> <li> Added <code>isManualCaseCreationEnabled</code> to return object.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2205/files#diff-db9ce3b32ce384de9f700a802ad04d2142d537ce7f0ed51256e7b3e24903786a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>migration.sql</strong><dd><code>Database Migration to Add displayName Column</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/prisma/migrations/20240314123948_definition_display_name/migration.sql
- Added `displayName` column to `WorkflowDefinition` table.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2205/files#diff-e3c04dd8aff5fc830991cc5c72a81764afafbc0a4dfdb323e48358542b893f83">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.prisma</strong><dd><code>Update Prisma Schema with displayName for WorkflowDefinition</code></dd></summary>
<hr>

services/workflows-service/prisma/schema.prisma
- Added optional `displayName` field to `WorkflowDefinition` model.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2205/files#diff-79f9532cd1d8e6c67881328fa550f851c8429f183de839b32575e959cdabef26">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data-migrations</strong><dd><code>Update Workflows Service Data Migrations Subproject Commit</code></dd></summary>
<hr>

services/workflows-service/prisma/data-migrations
- Updated subproject commit reference.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2205/files#diff-9c33eef7eba3ba7ca6006881973adb35d0cbc4048bb7256f945ab6da6f013edf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

