### PR TITLE
[wip]: ballerine dockerfile only with services

### DIFF
--- a/deploy/docker-compose-server.yml
+++ b/deploy/docker-compose-server.yml
@@ -1,0 +1,61 @@
+version: '3'
+services:
+  ballerine-workflow-service:
+    container_name: workflow-service
+    image: ghcr.io/ballerine-io/workflows-service:latest
+    command:
+      - /bin/sh
+      - -c
+      - |
+        npm run db:init
+        npm run seed
+        dumb-init npm run prod
+    ports:
+      - ${WORKFLOW_SVC_PORT}:${WORKFLOW_SVC_PORT}
+    environment:
+      BCRYPT_SALT: ${BCRYPT_SALT}
+      SESSION_EXPIRATION_IN_MINUTES: ${SESSION_EXPIRATION_IN_MINUTES}
+      DB_URL: postgres://${DB_USER}:${DB_PASSWORD}@postgres:${DB_PORT}
+      API_KEY: ${API_KEY}
+      NODE_ENV: ${NODE_ENV}
+      COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+      DB_PORT: ${DB_PORT}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      SESSION_SECRET: ${SESSION_SECRET}
+      BACKOFFICE_CORS_ORIGIN: http://${DOMAIN_NAME:-localhost}:${BACKOFFICE_PORT}
+      WORKFLOW_DASHBOARD_CORS_ORIGIN: http://${DOMAIN_NAME:-localhost}:${WORKFLOW_DASHBOARD_PORT}
+      PORT: ${WORKFLOW_SVC_PORT}
+      KYB_EXAMPLE_CORS_ORIGIN: http://${DOMAIN_NAME:-localhost}:${KYB_APP_PORT}
+      APP_API_URL: https://alon.ballerine.dev
+      EMAIL_API_TOKEN: ''
+      EMAIL_API_URL: https://api.sendgrid.com/v3/mail/send
+      UNIFIED_API_URL: 'https://unified-api-test.eu.ballerine.app'
+      UNIFIED_API_TOKEN: ''
+      UNIFIED_API_SHARED_SECRET: ''
+      ENVIRONMENT_NAME: 'development'
+    depends_on:
+      ballerine-postgres:
+        condition: service_healthy
+    restart: on-failure
+  ballerine-postgres:
+    container_name: postgres
+    image: sibedge/postgres-plv8:15.3-3.1.7
+    ports:
+      - ${DB_PORT}:${DB_PORT}
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+    volumes:
+      - postgres15:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        - CMD
+        - pg_isready
+        - -U
+        - admin
+      timeout: 45s
+      interval: 10s
+      retries: 10
+volumes:
+  postgres15: ~


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a new `docker-compose` configuration for deploying Ballerine services, specifically the `ballerine-workflow-service` and a PostgreSQL database (`ballerine-postgres`).
- The `ballerine-workflow-service` is configured to initialize the database, seed it, and start the service in production mode. It includes extensive environment variables for configuration, including database credentials, API keys, CORS settings, and more.
- The PostgreSQL service is set up with a custom `sibedge/postgres-plv8` image and includes a health check to ensure the database is ready before the workflow service starts.
- A persistent volume `postgres15` is defined for database data, ensuring data persistence across container restarts.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose-server.yml</strong><dd><code>Docker Compose Configuration for Ballerine Services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deploy/docker-compose-server.yml
<li>Introduced <code>docker-compose</code> configuration for <code>ballerine-workflow-service</code> <br>and <code>ballerine-postgres</code>.<br> <li> Configured <code>ballerine-workflow-service</code> with environment variables for <br>database, API keys, CORS origins, and service ports.<br> <li> Set up <code>ballerine-postgres</code> service with <br><code>sibedge/postgres-plv8:15.3-3.1.7</code> image and health check.<br> <li> Defined a volume <code>postgres15</code> for PostgreSQL data persistence.


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2242/files#diff-30eadd58f1f0fd8c8cd11a3d8ffe9c770f4b19b081dee8ef240e6add9148004e">+61/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

