### PR TITLE
fix: fixed missing conditional rendering of process tracker

### DIFF
--- a/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/utils/get-tabs-block-map.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/utils/get-tabs-block-map.tsx
@@ -46,7 +46,11 @@ export const getTabsToBlocksMap = (
   ] = blocks;
 
   const defaultTabsMap = {
-    summary: [...processTrackerBlock, ...websiteMonitoringBlock, ...entityInfoBlock],
+    summary: [
+      ...(workflow?.workflowDefinition?.config?.isCaseOverviewEnabled ? processTrackerBlock : []),
+      ...websiteMonitoringBlock,
+      ...entityInfoBlock,
+    ],
     company_information: [
       ...registryInfoBlock,
       ...kybRegistryInfoBlock,

--- a/apps/backoffice-v2/src/lib/blocks/variants/WebsiteMonitoringBlocks/WebsiteMonitoringBlocks.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/variants/WebsiteMonitoringBlocks/WebsiteMonitoringBlocks.tsx
@@ -13,7 +13,9 @@ export const WebsiteMonitoringBlocks = () => {
 
   return (
     <div className="flex h-full flex-col">
-      <ProcessTracker workflow={workflow} plugins={plugins} />
+      {workflow?.workflowDefinition?.config?.isCaseOverviewEnabled && (
+        <ProcessTracker workflow={workflow} plugins={plugins} />
+      )}
       <BlocksComponent blocks={blocks} cells={cells}>
         {(Cell, cell) => <Cell {...cell} />}
       </BlocksComponent>


### PR DESCRIPTION
## **User description**
### Description
- Process Tracker now renders conditionally within tabs & website motiroing


___

## **Type**
bug_fix


___

## **Description**
- Added conditional rendering for the `ProcessTracker` component in both the tabs block map and the website monitoring blocks. This ensures that the `ProcessTracker` is only rendered when the `isCaseOverviewEnabled` flag is true in the workflow configuration.
- This change improves the UI by preventing the unnecessary rendering of the `ProcessTracker` component when it is not enabled in the workflow configuration.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>get-tabs-block-map.tsx</strong><dd><code>Conditional Rendering for Process Tracker in Tabs Map</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/utils/get-tabs-block-map.tsx
<li>Conditional rendering added for <code>processTrackerBlock</code> based on <br><code>isCaseOverviewEnabled</code> flag.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2292/files#diff-094e2b019c86b48e710df731706c6204acf5c104552901f05545bf3d26adc034">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WebsiteMonitoringBlocks.tsx</strong><dd><code>Conditional Rendering for Process Tracker in Website Monitoring Blocks</code></dd></summary>
<hr>

apps/backoffice-v2/src/lib/blocks/variants/WebsiteMonitoringBlocks/WebsiteMonitoringBlocks.tsx
<li>Added conditional rendering for <code>ProcessTracker</code> component based on <br><code>isCaseOverviewEnabled</code> flag.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2292/files#diff-2952001991963e67fe8e2bbb356dc65a763b9acb99d6a480484c09ba8f17356d">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `summary` tab to conditionally include a `Process Tracker` based on configuration settings.
	- Added conditional rendering for the `Process Tracker` in the `Website Monitoring` section, dependent on workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->