### PR TITLE
fix: remove alert type

### DIFF
--- a/services/workflows-service/prisma/migrations/20240424132721_remove_alert_type/migration.sql
+++ b/services/workflows-service/prisma/migrations/20240424132721_remove_alert_type/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `type` on the `AlertDefinition` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "AlertDefinition" DROP COLUMN "type";
+
+-- DropEnum
+DROP TYPE "AlertType";

--- a/services/workflows-service/prisma/schema.prisma
+++ b/services/workflows-service/prisma/schema.prisma
@@ -704,16 +704,9 @@ enum AlertStatus {
   completed @map("300")
 }
 
-enum AlertType {
-  high_risk_transaction
-  dormant_account_activity
-  unusual_pattern
-}
-
 model AlertDefinition {
   id          String     @id @default(cuid())
   label       String
-  type        AlertType?
   name        String
   enabled     Boolean    @default(true)
   description String?

--- a/services/workflows-service/scripts/alerts/generate-alerts.ts
+++ b/services/workflows-service/scripts/alerts/generate-alerts.ts
@@ -7,7 +7,6 @@ import {
   AlertSeverity,
   AlertState,
   AlertStatus,
-  AlertType,
   Customer,
   PaymentMethod,
   Prisma,
@@ -347,7 +346,6 @@ export const getAlertDefinitionCreateData = (
   createdBy: string = 'SYSTEM',
 ) => ({
   label: label,
-  type: faker.helpers.arrayElement(Object.values(AlertType)) as AlertType,
   name: inlineRule.id,
   enabled: enabled ?? false,
   description: description || faker.lorem.sentence(),

--- a/services/workflows-service/src/alert/dtos/create-alert-definition.dto.ts
+++ b/services/workflows-service/src/alert/dtos/create-alert-definition.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, IsOptional, IsBoolean, IsEnum } from 'class-validator';
-import { AlertType } from '@prisma/client';
 
 export class CreateAlertDefinitionDto {
   @ApiProperty({ example: '[Payments] - High Cumulative Amount - Inbound' })
@@ -34,11 +33,6 @@ export class CreateAlertDefinitionDto {
   @ApiProperty({ example: true })
   @IsBoolean()
   enabled!: boolean;
-
-  @ApiProperty({ example: 'HighRiskTransaction', enum: AlertType, required: false })
-  @IsEnum(AlertType)
-  @IsOptional()
-  type?: AlertType;
 
   @ApiProperty({
     example: '{"invokeOnce": true, "invokeThrottleInSeconds": 60}',


### PR DESCRIPTION
## **Type**
Enhancement, Bug fix


___

## **Description**
- Removed all references and usages of the `AlertType` enum across various files including TypeScript scripts, DTOs, and Prisma schema.
- Executed a database migration to drop the `type` column and the `AlertType` enum from the database schema.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-alerts.ts</strong><dd><code>Remove AlertType Usage in Alert Generation Script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/scripts/alerts/generate-alerts.ts
- Removed usage of `AlertType` enum from alert generation logic.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2317/files#diff-65f82c5656fd8455fd436980f8c7d07ace7862374973f5493734b25cb69cce9f">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create-alert-definition.dto.ts</strong><dd><code>Remove AlertType from DTO Definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/src/alert/dtos/create-alert-definition.dto.ts
- Removed import and usage of `AlertType` enum in DTO definitions.



</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2317/files#diff-73305bb529da1f4db863e1ca5dc5f6c529750dba6968e59031f60c6622f83caf">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>migration.sql</strong><dd><code>SQL Migration to Remove AlertType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/prisma/migrations/20240424132721_remove_alert_type/migration.sql
<li>Dropped the <code>type</code> column from the <code>AlertDefinition</code> table.<br> <li> Dropped the <code>AlertType</code> enum type.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2317/files#diff-233c0833b4fbc78c6f5368782e89547d659946165fc40bccb1791ddc90b7c678">+11/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.prisma</strong><dd><code>Update Prisma Schema to Remove AlertType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/prisma/schema.prisma
<li>Removed the <code>AlertType</code> enum definition.<br> <li> Removed the <code>type</code> field from the <code>AlertDefinition</code> model.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2317/files#diff-79f9532cd1d8e6c67881328fa550f851c8429f183de839b32575e959cdabef26">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

