### PR TITLE
Fix flaky seed connection to businesses

### DIFF
--- a/services/workflows-service/scripts/seed.ts
+++ b/services/workflows-service/scripts/seed.ts
@@ -945,25 +945,6 @@ async function seed() {
     project1.id,
   );
 
-  await client.$transaction(async () =>
-    endUserIds.map(async (id, index) =>
-      client.endUser.create({
-        /// I tried to fix that so I can run through ajv, currently it doesn't like something in the schema (anyOf  )
-        data: generateEndUser({
-          id,
-          workflow: {
-            workflowDefinitionId: kycManualMachineId,
-            workflowDefinitionVersion: manualMachineVersion,
-            context: await createMockEndUserContextData(id, index + 1),
-            state: DEFAULT_INITIAL_STATE,
-          },
-          projectId: project1.id,
-          connectBusinesses: Math.random() > 0.5,
-        }),
-      }),
-    ),
-  );
-
   await client.$transaction(async tx => {
     businessRiskIds.map(async (id, index) => {
       const riskWf = async () => ({
@@ -1024,6 +1005,26 @@ async function seed() {
   //     },
   //   },
   // });
+
+  await client.$transaction(async () =>
+    endUserIds.map(async (id, index) =>
+      client.endUser.create({
+        /// I tried to fix that so I can run through ajv, currently it doesn't like something in the schema (anyOf  )
+        data: generateEndUser({
+          id,
+          workflow: {
+            workflowDefinitionId: kycManualMachineId,
+            workflowDefinitionVersion: manualMachineVersion,
+            context: await createMockEndUserContextData(id, index + 1),
+            state: DEFAULT_INITIAL_STATE,
+          },
+          projectId: project1.id,
+          connectBusinesses: Math.random() > 0.5,
+        }),
+      }),
+    ),
+  );
+
   void client.$disconnect();
 
   console.info('Seeding database with custom seed...');


### PR DESCRIPTION
### **User description**
### Description
Elaborate on the subject, motivation, and context.

### Related issues
 * Provide a link to each related issue.

### Breaking changes
 * Describe the breaking changes that this pull request introduces.

### How these changes were tested
 * Describe the tests that you ran to verify your changes, including devices, operating systems, browsers and versions.

### Examples and references
 * Links, screenshots, and other resources related to this change.

### Checklist
- [] I have read the [contribution guidelines](CONTRIBUTING.md) of this project
- [] I have read the [style guidelines](STYLE_GUIDE.md) of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings and errors
- [] New and existing tests pass locally with my changes


___

### **PR Type**
enhancement


___

### **Description**
- The PR modifies the `seed.ts` script to adjust the order of operations, ensuring that end users are created after business risk workflows.
- This adjustment aims to enhance the reliability of business connections to end users during the seeding process.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seed.ts</strong><dd><code>Refactor End User Creation Order in Seeding Script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

services/workflows-service/scripts/seed.ts
<li>Moved the creation of end users in the seeding script to occur after <br>the business risk workflows.<br> <li> This change ensures that businesses are connected to end users more <br>reliably.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ballerine-io/ballerine/pull/2356/files#diff-f1d8de203cd513c3d62628f31af33153ed7a484b71329717c99bd0070cbbd7a3">+20/-19</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Revert**
	- Restored the original method of creating user entities within transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->