### PR TITLE
dev-250/dependency-of-release-action-on wf-service-ci

### DIFF
--- a/.github/workflows/publish-workflows-service.yml
+++ b/.github/workflows/publish-workflows-service.yml
@@ -32,8 +32,6 @@ env:
 jobs:
   call_release:
     uses: ./.github/workflows/release.yml
-    with:
-      run-tests: true
 
   determine_branch:
     runs-on: ubuntu-latest
@@ -53,6 +51,7 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     needs: [determine_branch,call_release]
+    if: ${{ needs.call_release.result=='success' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-workflows-service.yml
+++ b/.github/workflows/publish-workflows-service.yml
@@ -30,6 +30,11 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/workflows-service
 
 jobs:
+  call_release:
+    uses: ./.github/workflows/release.yml
+    with:
+      run-tests: true
+
   determine_branch:
     runs-on: ubuntu-latest
     outputs:
@@ -47,7 +52,7 @@ jobs:
 
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: determine_branch
+    needs: [determine_branch,call_release]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Release
 
 on:
+  workflow_call:
+    inputs:
+      run-tests:
+        description: 'Run tests'
+        required: true
+        type: boolean
   push:
     branches:
       - dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,10 @@
 name: Release
 
 on:
-  workflow_call:
-    inputs:
-      run-tests:
-        description: 'Run tests'
-        required: true
-        type: boolean
   push:
     branches:
       - dev
+  workflow_call:
       
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR contains fix where I made release.yml as re-usable workflow which will be run from the publish-workflow-service and the build-and-push-docker-image job will need this action to be completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced CI/CD pipeline with a new release workflow for improved automation and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->