### PR TITLE
Setting isCaseOverviewEnabled default to false

### DIFF
--- a/apps/backoffice-v2/src/domains/workflow-definitions/fetchers.ts
+++ b/apps/backoffice-v2/src/domains/workflow-definitions/fetchers.ts
@@ -25,7 +25,7 @@ export const WorkflowDefinitionConfigSchema = z
     enableManualCreation: z.boolean().default(false),
     isManualCreation: z.boolean().default(false),
     isAssociatedCompanyKybEnabled: z.boolean().default(false),
-    isCaseOverviewEnabled: z.boolean().default(true),
+    isCaseOverviewEnabled: z.boolean().default(false),
     isCaseRiskOverviewEnabled: z.boolean().default(false),
     theme: WorkflowDefinitionConfigThemeSchema.default({
       type: WorkflowDefinitionConfigThemeEnum.KYB,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Changed the default setting for the `isCaseOverviewEnabled` property to `false` for new workflow definitions, providing more control over case overview visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->