### PR TITLE
bug/impelent_error_persistence

### DIFF
--- a/apps/backoffice-v2/CHANGELOG.md
+++ b/apps/backoffice-v2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ballerine/backoffice-v2
 
+## 0.7.19
+
+### Patch Changes
+
+- @ballerine/workflow-browser-sdk@0.6.20
+- @ballerine/workflow-node-sdk@0.6.20
+
 ## 0.7.18
 
 ### Patch Changes

--- a/apps/backoffice-v2/package.json
+++ b/apps/backoffice-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ballerine/backoffice-v2",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Ballerine - Backoffice",
   "homepage": "https://github.com/ballerine-io/ballerine",
   "repository": {
@@ -54,8 +54,8 @@
     "@ballerine/common": "0.9.12",
     "@ballerine/react-pdf-toolkit": "^1.2.6",
     "@ballerine/ui": "^0.5.6",
-    "@ballerine/workflow-browser-sdk": "0.6.19",
-    "@ballerine/workflow-node-sdk": "0.6.19",
+    "@ballerine/workflow-browser-sdk": "0.6.20",
+    "@ballerine/workflow-node-sdk": "0.6.20",
     "@fontsource/inter": "^4.5.15",
     "@formkit/auto-animate": "1.0.0-beta.5",
     "@hookform/resolvers": "^3.1.0",

--- a/apps/kyb-app/CHANGELOG.md
+++ b/apps/kyb-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # kyb-app
 
+## 0.3.20
+
+### Patch Changes
+
+- @ballerine/workflow-browser-sdk@0.6.20
+
 ## 0.3.19
 
 ### Patch Changes

--- a/apps/kyb-app/package.json
+++ b/apps/kyb-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/kyb-app",
   "private": true,
-  "version": "0.3.19",
+  "version": "0.3.20",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -17,7 +17,7 @@
     "@ballerine/common": "^0.9.12",
     "@ballerine/blocks": "0.2.6",
     "@ballerine/ui": "0.5.6",
-    "@ballerine/workflow-browser-sdk": "0.6.19",
+    "@ballerine/workflow-browser-sdk": "0.6.20",
     "@lukemorales/query-key-factory": "^1.0.3",
     "@radix-ui/react-icons": "^1.3.0",
     "@rjsf/core": "^5.9.0",

--- a/examples/headless-example/CHANGELOG.md
+++ b/examples/headless-example/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ballerine/headless-example
 
+## 0.3.19
+
+### Patch Changes
+
+- @ballerine/workflow-browser-sdk@0.6.20
+
 ## 0.3.18
 
 ### Patch Changes

--- a/examples/headless-example/package.json
+++ b/examples/headless-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/headless-example",
   "private": true,
-  "version": "0.3.18",
+  "version": "0.3.19",
   "type": "module",
   "scripts": {
     "spellcheck": "cspell \"*\"",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@ballerine/common": "0.9.12",
-    "@ballerine/workflow-browser-sdk": "0.6.19",
+    "@ballerine/workflow-browser-sdk": "0.6.20",
     "@felte/reporter-svelte": "^1.1.5",
     "@felte/validator-zod": "^1.0.13",
     "@fontsource/inter": "^4.5.15",

--- a/packages/workflow-core/CHANGELOG.md
+++ b/packages/workflow-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ballerine/workflow-core
 
+## 0.6.20
+
+### Patch Changes
+
+- added errored plugins persist to destination logic
+
 ## 0.6.19
 
 ### Patch Changes

--- a/packages/workflow-core/package.json
+++ b/packages/workflow-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/workflow-core",
   "author": "Ballerine <dev@ballerine.com>",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "workflow-core",
   "module": "./dist/esm/index.js",
   "main": "./dist/cjs/index.js",

--- a/packages/workflow-core/src/lib/workflow-runner.ts
+++ b/packages/workflow-core/src/lib/workflow-runner.ts
@@ -738,12 +738,20 @@ export class WorkflowRunner {
       return;
     }
 
-    if (apiPlugin.persistResponseDestination && responseBody) {
-      this.context = this.mergeToContext(
-        this.context,
-        responseBody,
-        apiPlugin.persistResponseDestination,
-      );
+    if (apiPlugin.persistResponseDestination) {
+      if (responseBody) {
+        this.context = this.mergeToContext(
+          this.context,
+          responseBody,
+          apiPlugin.persistResponseDestination,
+        );
+      } else if (error) {
+        this.context = this.mergeToContext(
+          this.context,
+          { error: error },
+          apiPlugin.persistResponseDestination,
+        );
+      }
     } else {
       this.context.pluginsOutput = {
         ...(this.context.pluginsOutput || {}),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,10 +73,10 @@ importers:
         specifier: ^0.5.6
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
-        specifier: 0.6.19
+        specifier: 0.6.20
         version: link:../../sdks/workflow-browser-sdk
       '@ballerine/workflow-node-sdk':
-        specifier: 0.6.19
+        specifier: 0.6.20
         version: link:../../sdks/workflow-node-sdk
       '@fontsource/inter':
         specifier: ^4.5.15
@@ -419,7 +419,7 @@ importers:
         specifier: 0.5.6
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
-        specifier: 0.6.19
+        specifier: 0.6.20
         version: link:../../sdks/workflow-browser-sdk
       '@lukemorales/query-key-factory':
         specifier: ^1.0.3
@@ -847,7 +847,7 @@ importers:
         specifier: 0.9.12
         version: link:../../packages/common
       '@ballerine/workflow-browser-sdk':
-        specifier: 0.6.19
+        specifier: 0.6.20
         version: link:../../sdks/workflow-browser-sdk
       '@felte/reporter-svelte':
         specifier: ^1.1.5
@@ -2058,7 +2058,7 @@ importers:
         specifier: 0.9.12
         version: link:../../packages/common
       '@ballerine/workflow-core':
-        specifier: 0.6.19
+        specifier: 0.6.20
         version: link:../../packages/workflow-core
       xstate:
         specifier: ^4.37.0
@@ -2197,7 +2197,7 @@ importers:
   sdks/workflow-node-sdk:
     dependencies:
       '@ballerine/workflow-core':
-        specifier: 0.6.19
+        specifier: 0.6.20
         version: link:../../packages/workflow-core
       json-logic-js:
         specifier: ^2.0.2
@@ -2442,10 +2442,10 @@ importers:
         specifier: 0.9.12
         version: link:../../packages/common
       '@ballerine/workflow-core':
-        specifier: 0.6.19
+        specifier: 0.6.20
         version: link:../../packages/workflow-core
       '@ballerine/workflow-node-sdk':
-        specifier: 0.6.19
+        specifier: 0.6.20
         version: link:../../sdks/workflow-node-sdk
       '@faker-js/faker':
         specifier: ^7.6.0

--- a/sdks/workflow-browser-sdk/CHANGELOG.md
+++ b/sdks/workflow-browser-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ballerine/workflow-browser-sdk
 
+## 0.6.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @ballerine/workflow-core@0.6.20
+
 ## 0.6.19
 
 ### Patch Changes

--- a/sdks/workflow-browser-sdk/package.json
+++ b/sdks/workflow-browser-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/workflow-browser-sdk",
   "author": "Ballerine <dev@ballerine.com>",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "workflow-browser-sdk",
   "module": "./dist/esm/index.js",
   "main": "./dist/cjs/index.js",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@ballerine/common": "0.9.12",
-    "@ballerine/workflow-core": "0.6.19",
+    "@ballerine/workflow-core": "0.6.20",
     "xstate": "^4.37.0"
   },
   "devDependencies": {

--- a/sdks/workflow-node-sdk/CHANGELOG.md
+++ b/sdks/workflow-node-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ballerine/workflow-node-sdk
 
+## 0.6.20
+
+### Patch Changes
+
+- Updated dependencies
+  - @ballerine/workflow-core@0.6.20
+
 ## 0.6.19
 
 ### Patch Changes

--- a/sdks/workflow-node-sdk/package.json
+++ b/sdks/workflow-node-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/workflow-node-sdk",
   "author": "Ballerine <dev@ballerine.com>",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "workflow-node-sdk",
   "module": "./dist/esm/index.js",
   "main": "./dist/cjs/index.js",
@@ -28,7 +28,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@ballerine/workflow-core": "0.6.19",
+    "@ballerine/workflow-core": "0.6.20",
     "json-logic-js": "^2.0.2",
     "xstate": "^4.36.0"
   },

--- a/services/workflows-service/CHANGELOG.md
+++ b/services/workflows-service/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ballerine/workflows-service
 
+## 0.7.19
+
+### Patch Changes
+
+- added errored plugins persist to destination logic
+- Updated dependencies
+  - @ballerine/workflow-core@0.6.20
+  - @ballerine/workflow-node-sdk@0.6.20
+
 ## 0.7.18
 
 ### Patch Changes

--- a/services/workflows-service/package.json
+++ b/services/workflows-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/workflows-service",
   "private": false,
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "workflow-service",
   "scripts": {
     "spellcheck": "cspell \"*\"",
@@ -47,8 +47,8 @@
     "@aws-sdk/lib-storage": "3.347.1",
     "@aws-sdk/s3-request-presigner": "3.347.1",
     "@ballerine/common": "0.9.12",
-    "@ballerine/workflow-core": "0.6.19",
-    "@ballerine/workflow-node-sdk": "0.6.19",
+    "@ballerine/workflow-core": "0.6.20",
+    "@ballerine/workflow-node-sdk": "0.6.20",
     "@faker-js/faker": "^7.6.0",
     "@nestjs/axios": "^2.0.0",
     "@nestjs/common": "^9.3.12",


### PR DESCRIPTION
previously: Errors thrown by plugins were persisted hardcodedly to the pluginOutputs.[pluginName]
fix: persiste to persistence destination the errored plguins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added logic for persisting errored plugins to the destination in workflow services.

- **Updates**
  - Updated dependencies across various packages to version `0.6.20`.
  - Incremented version numbers for multiple packages to reflect dependency updates and new feature additions.

- **Improvements**
  - Enhanced error handling in workflow plugins to improve system reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->