### PR TITLE
Fixed wrong ad example href

### DIFF
--- a/apps/backoffice-v2/src/domains/business-reports/components/AdExample/AdExample.tsx
+++ b/apps/backoffice-v2/src/domains/business-reports/components/AdExample/AdExample.tsx
@@ -18,7 +18,7 @@ export const AdExample: FunctionComponent<{
           variant: 'link',
           className: 'h-[unset] cursor-pointer !p-0 !text-[#14203D] underline decoration-[1.5px]',
         })}
-        href={src}
+        href={link}
       >
         {link}
       </a>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated `AdExample` component to use `link` instead of `src` for anchor tags.
- **Chores**
  - Updated the subproject commit hash in workflows service data migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->