### PR TITLE
chore: reverting the condition to run release action before publish work-flow service

### DIFF
--- a/.github/workflows/publish-workflows-service.yml
+++ b/.github/workflows/publish-workflows-service.yml
@@ -31,9 +31,6 @@ env:
 
   
 jobs:
-  call_release:
-    uses: ./.github/workflows/release.yml
-    secrets: inherit
 
   determine_branch:
     runs-on: ubuntu-latest
@@ -52,8 +49,7 @@ jobs:
 
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: [determine_branch,call_release]
-    if: ${{ needs.call_release.result=='success' }}
+    needs: [determine_branch]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-  workflow_call:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
…ork-flow service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the CI/CD workflow by removing the `call_release` job, streamlining the build process.
	- Updated dependencies in the `build-and-push-image` job for improved efficiency.
	- Removed the `workflow_call` trigger from the release workflow, simplifying trigger conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->