### PR TITLE
fix: adds missing env in docker compose files

### DIFF
--- a/deploy/docker-compose-build-https.yml
+++ b/deploy/docker-compose-build-https.yml
@@ -62,6 +62,7 @@ services:
       ENVIRONMENT_NAME: 'development'
       HASHING_KEY_SECRET: ${HASHING_KEY_SECRET}
       HASHING_KEY_SECRET_BASE64: ${HASHING_KEY_SECRET_BASE64}
+      NOTION_API_KEY: ${NOTION_API_KEY}
     depends_on:
       ballerine-postgres:
         condition: service_healthy

--- a/deploy/docker-compose-build.yml
+++ b/deploy/docker-compose-build.yml
@@ -62,6 +62,7 @@ services:
       ENVIRONMENT_NAME: 'development'
       HASHING_KEY_SECRET: ${HASHING_KEY_SECRET}
       HASHING_KEY_SECRET_BASE64: ${HASHING_KEY_SECRET_BASE64}
+      NOTION_API_KEY: ${NOTION_API_KEY}
     depends_on:
       ballerine-postgres:
         condition: service_healthy


### PR DESCRIPTION
Adds a missing env, without this docker installation as per the steps mentioned in docs [here](https://docs.ballerine.com/en/deployment/docker_compose/)  are failing with below error.

<img width="1161" alt="image" src="https://github.com/user-attachments/assets/28309be0-3245-4797-9d7c-e6be890b555e">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Notion API integration by introducing a new environment variable, `NOTION_API_KEY`, in service configurations.
  
- **Bug Fixes**
	- No bugs reported in this release. 

- **Documentation**
	- Updated service configuration documentation to reflect the new Notion API key requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->