### PR TITLE
fix(wf-def): disallow template editing

### DIFF
--- a/services/workflows-service/src/workflow-defintion/workflow-definition.repository.ts
+++ b/services/workflows-service/src/workflow-defintion/workflow-definition.repository.ts
@@ -122,10 +122,19 @@ export class WorkflowDefinitionRepository {
     projectIds: TProjectIds,
     noValidate = false,
   ): Promise<Prisma.BatchPayload> {
+    const workflowDefinition = await this.prisma.workflowDefinition.findUnique({
+      where: { id },
+      select: { isPublic: true },
+    });
+
+    if (workflowDefinition?.isPublic) {
+      throw new Error('Cannot update public workflow definition templates');
+    }
+
     const scopedArgs = this.scopeService.scopeUpdateMany(
       {
         ...args,
-        where: { id },
+        where: { id, isPublic: false },
       },
       projectIds,
     );
@@ -142,6 +151,14 @@ export class WorkflowDefinitionRepository {
     args: Prisma.SelectSubset<T, Omit<Prisma.WorkflowDefinitionDeleteArgs, 'where'>>,
     projectIds: TProjectIds,
   ): Promise<WorkflowDefinition> {
+    const workflowDefinition = await this.prisma.workflowDefinition.findUnique({
+      where: { id },
+      select: { isPublic: true },
+    });
+
+    if (workflowDefinition?.isPublic) {
+      throw new Error('Cannot delete public workflow definition templates');
+    }
     return await this.prisma.workflowDefinition.delete(
       this.scopeService.scopeDelete(
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added safeguards to prevent modifications to public workflow definition templates.
	- Introduced a new parameter to specify if a workflow definition is public in the workflow definition builder.
  
- **Bug Fixes**
	- Implemented error handling to block updates and deletions of public workflow definitions.

- **Tests**
	- Expanded test suite to verify that public workflow definitions cannot be edited and can be retrieved successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->