### PR TITLE
fix(ci-cd): adding image tag for migrations in default action

### DIFF
--- a/.github/workflows/publish-workflows-service.yml
+++ b/.github/workflows/publish-workflows-service.yml
@@ -221,7 +221,10 @@ jobs:
           changes: |
             {
               "kubernetes/helm/wf-service/${{steps.update_helm_check.outputs.file_name}}": {
-                "image.tag": "${{ needs.build-and-push-ee-image.outputs.docker_tag }}"
+                "image.tag": "${{ needs.build-and-push-ee-image.outputs.docker_tag }}",
+                "prismaMigrate.image.tag": "${{ needs.build-and-push-ee-image.outputs.docker_tag }}",
+                "dbMigrate.image.tag": "${{ needs.build-and-push-ee-image.outputs.docker_tag }}",
+                "dataSync.image.tag": "${{ needs.build-and-push-ee-image.outputs.docker_tag }}"
               }
             }
 

--- a/.github/workflows/test-db-ops.yaml
+++ b/.github/workflows/test-db-ops.yaml
@@ -76,7 +76,6 @@ jobs:
           changes: |
             {
               "kubernetes/helm/wf-service/${{steps.update_helm_check.outputs.file_name}}": {
-                "prismaMigrate.image.tag": "${{ inputs.tag }}",
                 "dbMigrate.image.tag": "${{ inputs.tag }}",
                 "dataSync.image.tag": "${{ inputs.tag }}"
               }


### PR DESCRIPTION
Added fix for running migrations along with deployment even on old workflow.
And run only db-migrations and db-sync on db-ops workflow as per suggested by Lior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced deployment configuration for consistency across multiple components (Prisma migration, database migration, and data synchronization) by standardizing Docker image tags.

- **Bug Fixes**
	- Adjusted workflow to prevent potential issues with Prisma migration image tags by removing a conflicting line, ensuring smoother deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->