### PR TITLE
feat(assign-dropdown): add role filtering for assignees

### DIFF
--- a/apps/backoffice-v2/src/common/components/atoms/AssignDropdown/AssignDropdown.tsx
+++ b/apps/backoffice-v2/src/common/components/atoms/AssignDropdown/AssignDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useMemo } from 'react';
+import { FunctionComponent, useMemo } from 'react';
 
 import { CheckSvg, DoubleCaretSvg, UnassignedAvatarSvg } from '../icons';
 import { DropdownMenu } from '../../molecules/DropdownMenu/DropdownMenu';
@@ -12,7 +12,7 @@ import { filterUsersByRole, TUserRole } from '@/domains/users/utils/filter-users
 export type TAssignee = Pick<TAuthenticatedUser, 'id' | 'fullName' | 'avatarUrl'>;
 
 interface IAssignDropdownProps {
-  assignees: TAssignee[];
+  assignees: TAuthenticatedUser[];
   assignedUser?: TAssignee;
   authenticatedUserId: string;
   onAssigneeSelect: (id: string) => void;
@@ -29,7 +29,7 @@ export const AssignDropdown: FunctionComponent<IAssignDropdownProps> = ({
   excludedRoles = [],
 }) => {
   const filteredAssignees = useMemo(
-    () => filterUsersByRole(assignees as Array<Partial<TAuthenticatedUser>>, excludedRoles),
+    () => filterUsersByRole(assignees, excludedRoles),
     [assignees, excludedRoles],
   );
 

--- a/apps/backoffice-v2/src/common/components/atoms/AssignDropdown/AssignDropdown.tsx
+++ b/apps/backoffice-v2/src/common/components/atoms/AssignDropdown/AssignDropdown.tsx
@@ -7,6 +7,7 @@ import { DropdownMenuTrigger } from '../../molecules/DropdownMenu/DropdownMenu.T
 import { DropdownMenuContent } from '../../molecules/DropdownMenu/DropdownMenu.Content';
 import { UserAvatar } from '../UserAvatar/UserAvatar';
 import { TAuthenticatedUser } from '../../../../domains/auth/types';
+import { filterUsersByRole, TUserRole } from '@/domains/users/utils/filter-users-by-role';
 
 export type TAssignee = Pick<TAuthenticatedUser, 'id' | 'fullName' | 'avatarUrl'>;
 
@@ -16,6 +17,7 @@ interface IAssignDropdownProps {
   authenticatedUserId: string;
   onAssigneeSelect: (id: string) => void;
   isDisabled?: boolean;
+  excludedRoles?: TUserRole[];
 }
 
 export const AssignDropdown: FunctionComponent<IAssignDropdownProps> = ({
@@ -24,16 +26,21 @@ export const AssignDropdown: FunctionComponent<IAssignDropdownProps> = ({
   onAssigneeSelect,
   authenticatedUserId,
   isDisabled,
+  excludedRoles = [],
 }) => {
+  const filteredAssignees = useMemo(
+    () => filterUsersByRole(assignees as Array<Partial<TAuthenticatedUser>>, excludedRoles),
+    [assignees, excludedRoles],
+  );
+
   const sortedAssignees = useMemo(
     () =>
-      // Sort assignees so that the authenticated user is always first
-      assignees
+      filteredAssignees
         ?.slice()
         ?.sort((a, b) =>
           a?.id === authenticatedUserId ? -1 : b?.id === authenticatedUserId ? 1 : 0,
         ),
-    [assignees, authenticatedUserId],
+    [filteredAssignees, authenticatedUserId],
   );
 
   return (

--- a/apps/backoffice-v2/src/domains/users/utils/filter-users-by-role.ts
+++ b/apps/backoffice-v2/src/domains/users/utils/filter-users-by-role.ts
@@ -1,0 +1,18 @@
+import { TAuthenticatedUser } from '@/domains/auth/types';
+
+export type TUserRole = 'viewer';
+
+export const filterUsersByRole = (
+  users: Array<Partial<TAuthenticatedUser>>,
+  excludedRoles: TUserRole[],
+) => {
+  return users.filter(user => {
+    if (!user) return false;
+
+    // If user has no roles, include them
+    if (!('roles' in user)) return true;
+
+    // Exclude user if they have any of the excluded roles
+    return !excludedRoles.some(role => Array.isArray(user.roles) && user.roles.includes(role));
+  });
+};

--- a/apps/backoffice-v2/src/domains/users/utils/filter-users-by-role.ts
+++ b/apps/backoffice-v2/src/domains/users/utils/filter-users-by-role.ts
@@ -9,10 +9,8 @@ export const filterUsersByRole = (
   return users.filter(user => {
     if (!user) return false;
 
-    // If user has no roles, include them
     if (!('roles' in user)) return true;
 
-    // Exclude user if they have any of the excluded roles
     return !excludedRoles.some(role => Array.isArray(user.roles) && user.roles.includes(role));
   });
 };

--- a/apps/backoffice-v2/src/domains/users/utils/filter-users-by-role.ts
+++ b/apps/backoffice-v2/src/domains/users/utils/filter-users-by-role.ts
@@ -6,6 +6,8 @@ export const filterUsersByRole = (
   users: Array<Partial<TAuthenticatedUser>>,
   excludedRoles: TUserRole[],
 ) => {
+  if (!Array.isArray(users)) return [];
+
   return users.filter(user => {
     if (!user) return false;
 

--- a/apps/backoffice-v2/src/domains/users/utils/filter-users-by-role.ts
+++ b/apps/backoffice-v2/src/domains/users/utils/filter-users-by-role.ts
@@ -11,8 +11,10 @@ export const filterUsersByRole = (
   return users.filter(user => {
     if (!user) return false;
 
-    if (!('roles' in user)) return true;
+    if (!('roles' in user) || !Array.isArray(user.roles)) {
+      return true;
+    }
 
-    return !excludedRoles.some(role => Array.isArray(user.roles) && user.roles.includes(role));
+    return !excludedRoles.some(role => user.roles.includes(role));
   });
 };

--- a/apps/backoffice-v2/src/domains/users/validation-schemas.ts
+++ b/apps/backoffice-v2/src/domains/users/validation-schemas.ts
@@ -12,6 +12,7 @@ export const UsersListSchema = z
       avatarUrl: z.string().nullable().optional(),
       createdAt: z.string(),
       updatedAt: z.string(),
+      roles: z.array(z.union([z.enum(['viewer', 'admin']), z.string()])).optional(),
     }).transform(({ firstName, lastName, ...rest }) => ({
       ...rest,
       firstName,

--- a/apps/backoffice-v2/src/pages/Entity/components/Case/Case.Actions.tsx
+++ b/apps/backoffice-v2/src/pages/Entity/components/Case/Case.Actions.tsx
@@ -58,6 +58,7 @@ export const Actions: FunctionComponent<IActionsProps> = ({
           }}
           authenticatedUserId={authenticatedUser?.id}
           isDisabled={isWorkflowCompleted}
+          excludedRoles={['viewer']}
         />
         <CaseOptions />
       </div>

--- a/apps/backoffice-v2/src/pages/TransactionMonitoringAlerts/components/AlertsAssignDropdown/AlertsAssignDropdown.tsx
+++ b/apps/backoffice-v2/src/pages/TransactionMonitoringAlerts/components/AlertsAssignDropdown/AlertsAssignDropdown.tsx
@@ -3,22 +3,29 @@ import { TUsers } from '@/domains/users/types';
 import { DoubleCaretSvg, UnassignedAvatarSvg } from '@/common/components/atoms/icons';
 import { UserAvatar } from '@/common/components/atoms/UserAvatar/UserAvatar';
 import { Dropdown } from '@/common/components/molecules/Dropdown/Dropdown';
+import { filterUsersByRole, TUserRole } from '@/domains/users/utils/filter-users-by-role';
+import { TAuthenticatedUser } from '@/domains/auth/types';
 
 export const AlertsAssignDropdown: FunctionComponent<{
   assignees: TUsers;
   authenticatedUserId: string;
   isDisabled: boolean;
   onAssigneeSelect: (id: string | null, isAssignedToMe: boolean) => () => void;
-}> = ({ assignees, authenticatedUserId, isDisabled, onAssigneeSelect }) => {
+  excludedRoles?: TUserRole[];
+}> = ({ assignees, authenticatedUserId, isDisabled, onAssigneeSelect, excludedRoles = [] }) => {
+  const filteredAssignees = useMemo(
+    () => filterUsersByRole(assignees as Array<Partial<TAuthenticatedUser>>, excludedRoles),
+    [assignees, excludedRoles],
+  );
+
   const sortedAssignees = useMemo(
     () =>
-      // Sort assignees so that the authenticated user is always first
-      assignees
+      filteredAssignees
         ?.slice()
         ?.sort((a, b) =>
           a?.id === authenticatedUserId ? -1 : b?.id === authenticatedUserId ? 1 : 0,
         ),
-    [assignees, authenticatedUserId],
+    [filteredAssignees, authenticatedUserId],
   );
 
   const options = useMemo(() => {

--- a/apps/backoffice-v2/src/pages/TransactionMonitoringAlerts/components/AlertsAssignDropdown/AlertsAssignDropdown.tsx
+++ b/apps/backoffice-v2/src/pages/TransactionMonitoringAlerts/components/AlertsAssignDropdown/AlertsAssignDropdown.tsx
@@ -1,10 +1,9 @@
-import React, { FunctionComponent, useMemo } from 'react';
+import { FunctionComponent, useMemo } from 'react';
 import { TUsers } from '@/domains/users/types';
 import { DoubleCaretSvg, UnassignedAvatarSvg } from '@/common/components/atoms/icons';
 import { UserAvatar } from '@/common/components/atoms/UserAvatar/UserAvatar';
 import { Dropdown } from '@/common/components/molecules/Dropdown/Dropdown';
 import { filterUsersByRole, TUserRole } from '@/domains/users/utils/filter-users-by-role';
-import { TAuthenticatedUser } from '@/domains/auth/types';
 
 export const AlertsAssignDropdown: FunctionComponent<{
   assignees: TUsers;
@@ -14,7 +13,7 @@ export const AlertsAssignDropdown: FunctionComponent<{
   excludedRoles?: TUserRole[];
 }> = ({ assignees, authenticatedUserId, isDisabled, onAssigneeSelect, excludedRoles = [] }) => {
   const filteredAssignees = useMemo(
-    () => filterUsersByRole(assignees as Array<Partial<TAuthenticatedUser>>, excludedRoles),
+    () => filterUsersByRole(assignees, excludedRoles),
     [assignees, excludedRoles],
   );
 

--- a/services/workflows-service/src/user/user.controller.internal.ts
+++ b/services/workflows-service/src/user/user.controller.internal.ts
@@ -36,6 +36,7 @@ export class UserControllerInternal {
           avatarUrl: true,
           updatedAt: true,
           createdAt: true,
+          roles: true,
         },
       },
       projectId ? [projectId] : projectIds,


### PR DESCRIPTION
- Introduce filterUsersByRole utility to exclude assignees by roles
- Update AssignDropdown and AlertsAssignDropdown to utilize filtering
- Set default excluded role to 'viewer' in relevant components

(Your role filtering is so selective, it's like a bouncer at a VIP club)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an `excludedRoles` property to the `AssignDropdown` and `AlertsAssignDropdown` components, allowing users to filter out specific roles from the dropdown options.
  - Enhanced filtering logic to prioritize authenticated users while excluding specified roles from the assignee list.
  - Added a `roles` property to the `UsersListSchema` validation schema for improved user role validation.

- **Bug Fixes**
  - Improved the handling of user roles in the dropdown components to ensure accurate filtering.

- **Documentation**
  - Updated prop signatures to reflect the addition of the `excludedRoles` property in relevant components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->