### PR TITLE
chore: add restart postgres incase of failure

### DIFF
--- a/deploy/docker-compose-build.yml
+++ b/deploy/docker-compose-build.yml
@@ -98,5 +98,6 @@ services:
       timeout: 45s
       interval: 10s
       retries: 10
+    restart: on-failure
 volumes:
   postgres15: ~


### PR DESCRIPTION
This helps in restarting postgres container incase there is a restart of the host or any error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced resilience of the PostgreSQL service with automatic restart on failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->