### PR TITLE
Removed gender from add ubo flow

### DIFF
--- a/apps/backoffice-v2/src/lib/blocks/hooks/useManageUbosBlock/ubos-form-json-definition.ts
+++ b/apps/backoffice-v2/src/lib/blocks/hooks/useManageUbosBlock/ubos-form-json-definition.ts
@@ -18,7 +18,6 @@ export const ubosFormJsonDefinition = {
         'company-ownership-passport-number-input',
         'company-ownership-date-of-birth-input',
         'company-ownership-nationality-input',
-        'company-ownership-gender-input',
         'company-ownership-country-input',
         'company-ownership-city-input',
       ],
@@ -173,32 +172,6 @@ export const ubosFormJsonDefinition = {
         },
         uiSchema: {
           'ui:field': 'NationalityPicker',
-        },
-      },
-    },
-    {
-      name: 'company-ownership-gender-input',
-      type: 'json-form:text',
-      valueDestination: 'gender',
-      options: {
-        label: 'text.companyOwnership.gender.label',
-        hint: 'text.companyOwnership.gender.placeholder',
-        jsonFormDefinition: {
-          type: 'string',
-          oneOf: [
-            {
-              title: 'text.companyOwnership.gender.male',
-              const: 'male',
-            },
-            {
-              title: 'text.companyOwnership.gender.female',
-              const: 'female',
-            },
-            {
-              title: 'text.companyOwnership.gender.other',
-              const: 'other',
-            },
-          ],
         },
       },
     },

--- a/services/workflows-service/src/case-management/case-management.service.ts
+++ b/services/workflows-service/src/case-management/case-management.service.ts
@@ -117,7 +117,6 @@ export class CaseManagementService {
             passportNumber: ubo.passportNumber,
             dateOfBirth: ubo.dateOfBirth,
             placeOfBirth: ubo.placeOfBirth,
-            gender: ubo.gender,
             country: ubo.country,
             city: ubo.city,
             street: ubo.street,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Form Configuration**
	- Removed gender input field from the UBO (Ultimate Beneficial Owner) form
	- Reduced required form fields from ten to nine

- **Data Processing**
	- Updated UBO creation workflow to remove gender property from entity adapter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->