### PR TITLE
feat: monthly filter on statistics page and additional merchant related data (BAL-3302, BAL-3303)

### DIFF
--- a/apps/backoffice-v2/src/common/hooks/useHomeLogic/useHomeLogic.ts
+++ b/apps/backoffice-v2/src/common/hooks/useHomeLogic/useHomeLogic.ts
@@ -1,17 +1,14 @@
-import { ComponentProps, useEffect } from 'react';
 import { DateRangePicker } from '@/common/components/molecules/DateRangePicker/DateRangePicker';
-import { useZodSearchParams } from '@/common/hooks/useZodSearchParams/useZodSearchParams';
-import { HomeSearchSchema } from '@/pages/Home/home-search-schema';
-import { useAuthenticatedUserQuery } from '@/domains/auth/hooks/queries/useAuthenticatedUserQuery/useAuthenticatedUserQuery';
 import { useLocale } from '@/common/hooks/useLocale/useLocale';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuthenticatedUserQuery } from '@/domains/auth/hooks/queries/useAuthenticatedUserQuery/useAuthenticatedUserQuery';
 import { useCustomerQuery } from '@/domains/customer/hooks/queries/useCustomerQuery/useCustomerQuery';
+import { ComponentProps, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export const useHomeLogic = () => {
   const locale = useLocale();
   const { pathname, search } = useLocation();
   const navigate = useNavigate();
-  const [{ from, to }, setSearchParams] = useZodSearchParams(HomeSearchSchema);
   const { data: session } = useAuthenticatedUserQuery();
   const { data: customer, isLoading: isLoadingCustomer } = useCustomerQuery();
   const isExample = customer?.config?.isExample;
@@ -29,23 +26,13 @@ export const useHomeLogic = () => {
     navigate(`/${locale}/home/statistics`);
   }, [pathname, locale, navigate]);
 
-  const onDateRangeChange: ComponentProps<typeof DateRangePicker>['onChange'] = range => {
-    const from = range?.from?.toISOString();
-    const to = range?.to?.toISOString();
-
-    setSearchParams({ from, to });
-  };
-
   return {
-    from,
-    to,
     firstName,
     fullName,
     avatarUrl,
     statisticsLink,
     workflowsLink,
     defaultTabValue,
-    onDateRangeChange,
     isLoadingCustomer,
     isExample,
     isDemo,

--- a/apps/backoffice-v2/src/common/hooks/useHomeLogic/useHomeLogic.ts
+++ b/apps/backoffice-v2/src/common/hooks/useHomeLogic/useHomeLogic.ts
@@ -1,8 +1,7 @@
-import { DateRangePicker } from '@/common/components/molecules/DateRangePicker/DateRangePicker';
 import { useLocale } from '@/common/hooks/useLocale/useLocale';
 import { useAuthenticatedUserQuery } from '@/domains/auth/hooks/queries/useAuthenticatedUserQuery/useAuthenticatedUserQuery';
 import { useCustomerQuery } from '@/domains/customer/hooks/queries/useCustomerQuery/useCustomerQuery';
-import { ComponentProps, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 export const useHomeLogic = () => {

--- a/apps/backoffice-v2/src/domains/auth/validation-schemas.ts
+++ b/apps/backoffice-v2/src/domains/auth/validation-schemas.ts
@@ -7,6 +7,8 @@ export const AuthenticatedUserSchema = z
     firstName: z.string(),
     lastName: z.string(),
     avatarUrl: z.string().nullable().optional(),
+    lastActiveAt: z.string().datetime().nullable().optional(),
+    registrationDate: z.string().datetime(),
   })
   .transform(({ firstName, lastName, ...other }) => ({
     ...other,

--- a/apps/backoffice-v2/src/domains/business-reports/hooks/queries/useBusinessReportMetricsQuery/useBusinessReportMetricsQuery.ts
+++ b/apps/backoffice-v2/src/domains/business-reports/hooks/queries/useBusinessReportMetricsQuery/useBusinessReportMetricsQuery.ts
@@ -38,7 +38,7 @@ export const useBusinessReportMetricsQuery = ({ from, to }: { from?: string; to?
   const isAuthenticated = useIsAuthenticated();
 
   return useQuery({
-    queryKey: ['business-report-metrics', from],
+    queryKey: ['business-report-metrics', from, to],
     queryFn: () => fetchBusinessReportMetrics({ from, to }),
     enabled: isAuthenticated,
     keepPreviousData: true,

--- a/apps/backoffice-v2/src/domains/business-reports/hooks/queries/useBusinessReportMetricsQuery/useBusinessReportMetricsQuery.ts
+++ b/apps/backoffice-v2/src/domains/business-reports/hooks/queries/useBusinessReportMetricsQuery/useBusinessReportMetricsQuery.ts
@@ -1,8 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
-import { useIsAuthenticated } from '@/domains/auth/context/AuthProvider/hooks/useIsAuthenticated/useIsAuthenticated';
 import { apiClient } from '@/common/api-client/api-client';
 import { Method } from '@/common/enums';
 import { handleZodError } from '@/common/utils/handle-zod-error/handle-zod-error';
+import { useIsAuthenticated } from '@/domains/auth/context/AuthProvider/hooks/useIsAuthenticated/useIsAuthenticated';
+import { useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 
 export const MetricsResponseSchema = z.object({
@@ -19,11 +19,14 @@ export const MetricsResponseSchema = z.object({
       count: z.number(),
     }),
   ),
+  totalActiveMerchants: z.number(),
+  addedMerchantsCount: z.number(),
+  removedMerchantsCount: z.number(),
 });
 
-export const fetchBusinessReportMetrics = async () => {
+export const fetchBusinessReportMetrics = async ({ from, to }: { from?: string; to?: string }) => {
   const [businessReportMetrics, error] = await apiClient({
-    endpoint: `../external/business-reports/metrics`,
+    endpoint: `../external/business-reports/metrics?from=${from}&to=${to}`,
     method: Method.GET,
     schema: MetricsResponseSchema,
   });
@@ -31,12 +34,12 @@ export const fetchBusinessReportMetrics = async () => {
   return handleZodError(error, businessReportMetrics);
 };
 
-export const useBusinessReportMetricsQuery = () => {
+export const useBusinessReportMetricsQuery = ({ from, to }: { from?: string; to?: string }) => {
   const isAuthenticated = useIsAuthenticated();
 
   return useQuery({
-    queryKey: ['business-report-metrics'],
-    queryFn: () => fetchBusinessReportMetrics(),
+    queryKey: ['business-report-metrics', from],
+    queryFn: () => fetchBusinessReportMetrics({ from, to }),
     enabled: isAuthenticated,
     keepPreviousData: true,
   });

--- a/apps/backoffice-v2/src/pages/Home/Home.page.tsx
+++ b/apps/backoffice-v2/src/pages/Home/Home.page.tsx
@@ -56,9 +56,8 @@ export const Home: FunctionComponent = () => {
         {/*    <Outlet />*/}
         {/*  </TabsContent>*/}
         {/*</Tabs>*/}
-        <Outlet />
-        {/* {(isDemo || isExample) && <Outlet />}
-        {!isDemo && !isExample && <WelcomeCard />} */}
+        {(isDemo || isExample) && <Outlet />}
+        {!isDemo && !isExample && <WelcomeCard />}
       </div>
     </div>
   );

--- a/apps/backoffice-v2/src/pages/Home/Home.page.tsx
+++ b/apps/backoffice-v2/src/pages/Home/Home.page.tsx
@@ -8,9 +8,6 @@ import { WelcomeCard } from '@/pages/Home/components/WelcomeCard/WelcomeCard';
 
 export const Home: FunctionComponent = () => {
   const {
-    onDateRangeChange,
-    from,
-    to,
     firstName,
     fullName,
     avatarUrl,
@@ -59,8 +56,9 @@ export const Home: FunctionComponent = () => {
         {/*    <Outlet />*/}
         {/*  </TabsContent>*/}
         {/*</Tabs>*/}
-        {(isDemo || isExample) && <Outlet />}
-        {!isDemo && !isExample && <WelcomeCard />}
+        <Outlet />
+        {/* {(isDemo || isExample) && <Outlet />}
+        {!isDemo && !isExample && <WelcomeCard />} */}
       </div>
     </div>
   );

--- a/apps/backoffice-v2/src/pages/Statistics/Statistics.page.tsx
+++ b/apps/backoffice-v2/src/pages/Statistics/Statistics.page.tsx
@@ -1,25 +1,35 @@
-import React, { FunctionComponent } from 'react';
-import { UserStatistics } from '@/pages/Statistics/components/UserStatistics/UserStatistics';
-import { PortfolioRiskStatistics } from '@/pages/Statistics/components/PortfolioRiskStatistics/PortfolioRiskStatistics';
-import { WorkflowStatistics } from '@/pages/Statistics/components/WorkflowStatistics/WorkflowStatistics';
 import { Loader2 } from 'lucide-react';
-import { useBusinessReportMetricsQuery } from '@/domains/business-reports/hooks/queries/useBusinessReportMetricsQuery/useBusinessReportMetricsQuery';
+import { FunctionComponent } from 'react';
+
+import { MonthPicker } from './components/MonthPicker/MonthPicker';
+import { PortfolioAnalytics } from './components/PortfolioAnalytics/PortfolioAnalytics';
+import { PortfolioRiskStatistics } from './components/PortfolioRiskStatistics/PortfolioRiskStatistics';
+import { useStatisticsLogic } from './hooks/useStatisticsLogic';
 
 export const Statistics: FunctionComponent = () => {
-  const { data, isLoading, error } = useBusinessReportMetricsQuery();
+  const { data, isLoading, error, date, setDate, registrationDate } = useStatisticsLogic();
 
   if (error) {
     throw error;
   }
 
   if (isLoading || !data) {
-    return <Loader2 className={'w-4 animate-spin'} />;
+    return <Loader2 className="w-4 animate-spin" />;
   }
 
   return (
     <div>
-      <h1 className={'pb-5 text-2xl font-bold'}>Statistics</h1>
-      <div className={'flex flex-col space-y-8'}>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Statistics</h1>
+        <MonthPicker date={date ?? new Date()} setDate={setDate} minDate={registrationDate} />
+      </div>
+
+      <div className="flex flex-col space-y-8">
+        <PortfolioAnalytics
+          totalActiveMerchants={data.totalActiveMerchants}
+          addedMerchantsCount={data.addedMerchantsCount}
+          removedMerchantsCount={data.removedMerchantsCount}
+        />
         {/* <UserStatistics fullName={'John Doe'} /> */}
         <PortfolioRiskStatistics
           riskLevelCounts={data.riskLevelCounts}

--- a/apps/backoffice-v2/src/pages/Statistics/Statistics.page.tsx
+++ b/apps/backoffice-v2/src/pages/Statistics/Statistics.page.tsx
@@ -21,7 +21,7 @@ export const Statistics: FunctionComponent = () => {
     <div>
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold">Statistics</h1>
-        <MonthPicker date={date ?? new Date()} setDate={setDate} minDate={registrationDate} />
+        <MonthPicker date={date} setDate={setDate} minDate={registrationDate} />
       </div>
 
       <div className="flex flex-col space-y-8">

--- a/apps/backoffice-v2/src/pages/Statistics/components/MonthPicker/MonthPicker.tsx
+++ b/apps/backoffice-v2/src/pages/Statistics/components/MonthPicker/MonthPicker.tsx
@@ -1,9 +1,9 @@
 import { Button, ctw, Popover, PopoverContent, PopoverTrigger } from '@ballerine/ui';
-import { format, isAfter, isBefore, setMonth, setYear, startOfMonth } from 'date-fns';
+import dayjs from 'dayjs';
 import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useState } from 'react';
 
-const today = new Date();
+const today = dayjs();
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 type MonthPickerProps = {
@@ -14,13 +14,16 @@ type MonthPickerProps = {
 
 export const MonthPicker = ({ date, setDate, minDate }: MonthPickerProps) => {
   const [open, setOpen] = useState(false);
-  const [currentYear, setCurrentYear] = useState(today.getFullYear());
+  const [currentYear, setCurrentYear] = useState(today.year());
+
+  const dayjsDate = dayjs(date);
+  const dayjsMinDate = minDate ? dayjs(minDate) : undefined;
 
   const handleMonthSelect = (monthIndex: number) => {
-    const newDate = setMonth(setYear(date, currentYear), monthIndex);
+    const newDate = dayjs(date).year(currentYear).month(monthIndex);
 
-    if (isBefore(newDate, today) || isSameMonth(newDate, today)) {
-      setDate(newDate);
+    if (newDate.isSame(today, 'month') || newDate.isBefore(today, 'month')) {
+      setDate(newDate.toDate());
       setOpen(false);
     }
   };
@@ -29,14 +32,14 @@ export const MonthPicker = ({ date, setDate, minDate }: MonthPickerProps) => {
     setCurrentYear(prevYear => prevYear + increment);
   };
 
-  const isSameMonth = (date1: Date, date2: Date) => {
-    return date1.getFullYear() === date2.getFullYear() && date1.getMonth() === date2.getMonth();
+  const isSameMonth = (date1: dayjs.Dayjs, date2: dayjs.Dayjs) => {
+    return date1.isSame(date2, 'month');
   };
 
   const isMonthDisabled = (monthIndex: number) => {
-    const monthDate = startOfMonth(setMonth(setYear(today, currentYear), monthIndex));
+    const monthDate = dayjs().year(currentYear).month(monthIndex).startOf('month');
 
-    return isAfter(monthDate, today);
+    return monthDate.isAfter(today, 'month');
   };
 
   return (
@@ -49,7 +52,7 @@ export const MonthPicker = ({ date, setDate, minDate }: MonthPickerProps) => {
             !date && 'text-muted-foreground',
           )}
         >
-          <span>{format(date, 'MMMM yyyy')}</span>
+          <span>{dayjsDate.format('MMMM YYYY')}</span>
           <ChevronDown className="ml-auto h-4 w-4 opacity-50" />
         </Button>
       </PopoverTrigger>
@@ -59,7 +62,7 @@ export const MonthPicker = ({ date, setDate, minDate }: MonthPickerProps) => {
             variant="outline"
             size="icon"
             onClick={() => handleYearChange(-1)}
-            disabled={minDate && currentYear <= minDate.getFullYear()}
+            disabled={dayjsMinDate && currentYear <= dayjsMinDate.year()}
           >
             <ChevronLeft className="h-4 w-4" />
           </Button>
@@ -68,7 +71,7 @@ export const MonthPicker = ({ date, setDate, minDate }: MonthPickerProps) => {
             variant="outline"
             size="icon"
             onClick={() => handleYearChange(1)}
-            disabled={currentYear >= today.getFullYear()}
+            disabled={currentYear >= today.year()}
           >
             <ChevronRight className="h-4 w-4" />
           </Button>
@@ -80,12 +83,14 @@ export const MonthPicker = ({ date, setDate, minDate }: MonthPickerProps) => {
               onClick={() => handleMonthSelect(index)}
               disabled={
                 isMonthDisabled(index) ||
-                (minDate && currentYear === minDate.getFullYear() && index < minDate.getMonth())
+                (dayjsMinDate &&
+                  currentYear === dayjsMinDate.year() &&
+                  index < dayjsMinDate.month())
               }
               variant="ghost"
               className={ctw(
                 'h-9 w-full',
-                isSameMonth(date, setMonth(setYear(new Date(), currentYear), index)) &&
+                isSameMonth(dayjsDate, dayjs().year(currentYear).month(index)) &&
                   'bg-primary text-primary-foreground',
               )}
             >

--- a/apps/backoffice-v2/src/pages/Statistics/components/MonthPicker/MonthPicker.tsx
+++ b/apps/backoffice-v2/src/pages/Statistics/components/MonthPicker/MonthPicker.tsx
@@ -1,0 +1,99 @@
+import { Button, ctw, Popover, PopoverContent, PopoverTrigger } from '@ballerine/ui';
+import { format, isAfter, isBefore, setMonth, setYear, startOfMonth } from 'date-fns';
+import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+
+const today = new Date();
+const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+type MonthPickerProps = {
+  date: Date;
+  setDate: (date: Date) => void;
+  minDate?: Date;
+};
+
+export const MonthPicker = ({ date, setDate, minDate }: MonthPickerProps) => {
+  const [open, setOpen] = useState(false);
+  const [currentYear, setCurrentYear] = useState(today.getFullYear());
+
+  const handleMonthSelect = (monthIndex: number) => {
+    const newDate = setMonth(setYear(date, currentYear), monthIndex);
+
+    if (isBefore(newDate, today) || isSameMonth(newDate, today)) {
+      setDate(newDate);
+      setOpen(false);
+    }
+  };
+
+  const handleYearChange = (increment: number) => {
+    setCurrentYear(prevYear => prevYear + increment);
+  };
+
+  const isSameMonth = (date1: Date, date2: Date) => {
+    return date1.getFullYear() === date2.getFullYear() && date1.getMonth() === date2.getMonth();
+  };
+
+  const isMonthDisabled = (monthIndex: number) => {
+    const monthDate = startOfMonth(setMonth(setYear(today, currentYear), monthIndex));
+
+    return isAfter(monthDate, today);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className={ctw(
+            'w-[240px] justify-start text-left font-normal',
+            !date && 'text-muted-foreground',
+          )}
+        >
+          <span>{format(date, 'MMMM yyyy')}</span>
+          <ChevronDown className="ml-auto h-4 w-4 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[240px] p-0" align="start">
+        <div className="flex items-center justify-between p-2">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => handleYearChange(-1)}
+            disabled={minDate && currentYear <= minDate.getFullYear()}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span>{currentYear}</span>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => handleYearChange(1)}
+            disabled={currentYear >= today.getFullYear()}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+        <div className="grid grid-cols-3 gap-2 p-2">
+          {months.map((month, index) => (
+            <Button
+              key={month}
+              onClick={() => handleMonthSelect(index)}
+              disabled={
+                isMonthDisabled(index) ||
+                (minDate && currentYear === minDate.getFullYear() && index < minDate.getMonth())
+              }
+              variant="ghost"
+              className={ctw(
+                'h-9 w-full',
+                isSameMonth(date, setMonth(setYear(new Date(), currentYear), index)) &&
+                  'bg-primary text-primary-foreground',
+              )}
+            >
+              {month}
+            </Button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/apps/backoffice-v2/src/pages/Statistics/components/PortfolioAnalytics/PortfolioAnalytics.tsx
+++ b/apps/backoffice-v2/src/pages/Statistics/components/PortfolioAnalytics/PortfolioAnalytics.tsx
@@ -1,0 +1,55 @@
+import { Card } from '@/common/components/atoms/Card/Card';
+import { CardContent } from '@/common/components/atoms/Card/Card.Content';
+import { CardHeader } from '@/common/components/atoms/Card/Card.Header';
+import { CardTitle } from '@/common/components/atoms/Card/Card.Title';
+import { MetricsResponseSchema } from '@/domains/business-reports/hooks/queries/useBusinessReportMetricsQuery/useBusinessReportMetricsQuery';
+import { UserMinus, UserPlus, Users } from 'lucide-react';
+import { FunctionComponent } from 'react';
+import { z } from 'zod';
+
+export const PortfolioAnalytics: FunctionComponent<
+  Pick<
+    z.infer<typeof MetricsResponseSchema>,
+    'totalActiveMerchants' | 'addedMerchantsCount' | 'removedMerchantsCount'
+  >
+> = ({ totalActiveMerchants, addedMerchantsCount, removedMerchantsCount }) => {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h3 className="text-xl font-semibold tracking-tight">Portfolio Analytics</h3>
+        <div className="flex items-center gap-2">
+          <Users className="h-4 w-4 text-muted-foreground" />
+          <p>
+            Total Active Merchants: <span className="font-semibold">{totalActiveMerchants}</span>
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">New Merchants Added</CardTitle>
+            <UserPlus className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {addedMerchantsCount > 0 ? `+${addedMerchantsCount}` : `0`}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Merchants Removed</CardTitle>
+            <UserMinus className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {removedMerchantsCount > 0 ? `-${removedMerchantsCount}` : `0`}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};

--- a/apps/backoffice-v2/src/pages/Statistics/components/PortfolioAnalytics/hooks/usePortfolioAnalyticsLogic.tsx
+++ b/apps/backoffice-v2/src/pages/Statistics/components/PortfolioAnalytics/hooks/usePortfolioAnalyticsLogic.tsx
@@ -11,7 +11,7 @@ import { MetricsResponseSchema } from '@/domains/business-reports/hooks/queries/
 export const usePortfolioRiskStatisticsLogic = ({
   riskLevelCounts,
   violationCounts,
-}: Pick<z.infer<typeof MetricsResponseSchema>, 'riskLevelCounts' | 'violationCounts'>) => {
+}: z.infer<typeof MetricsResponseSchema>) => {
   const [parent] = useAutoAnimate<HTMLTableSectionElement>();
   const [riskIndicatorsSorting, setRiskIndicatorsSorting] = useState<SortDirection>('desc');
   const onSortRiskIndicators = useCallback(

--- a/apps/backoffice-v2/src/pages/Statistics/components/PortfolioRiskStatistics/PortfolioRiskStatistics.tsx
+++ b/apps/backoffice-v2/src/pages/Statistics/components/PortfolioRiskStatistics/PortfolioRiskStatistics.tsx
@@ -21,10 +21,9 @@ import { MetricsResponseSchema } from '@/domains/business-reports/hooks/queries/
 import { Link, useNavigate } from 'react-router-dom';
 import { useLocale } from '@/common/hooks/useLocale/useLocale';
 
-export const PortfolioRiskStatistics: FunctionComponent<z.infer<typeof MetricsResponseSchema>> = ({
-  riskLevelCounts,
-  violationCounts,
-}) => {
+export const PortfolioRiskStatistics: FunctionComponent<
+  Pick<z.infer<typeof MetricsResponseSchema>, 'riskLevelCounts' | 'violationCounts'>
+> = ({ riskLevelCounts, violationCounts }) => {
   const {
     riskLevelToFillColor,
     parent,
@@ -44,7 +43,7 @@ export const PortfolioRiskStatistics: FunctionComponent<z.infer<typeof MetricsRe
 
   return (
     <div>
-      <h5 className={'mb-4 font-bold'}>Portfolio Risk Statistics</h5>
+      <h3 className={'mb-4 text-xl font-bold'}>Portfolio Risk Statistics</h3>
       <div className={'grid grid-cols-3 gap-6'}>
         <div className={'min-h-[27.5rem] rounded-xl bg-[#F6F6F6] p-2'}>
           <Card className={'flex h-full flex-col px-3'}>

--- a/apps/backoffice-v2/src/pages/Statistics/hooks/useStatisticsLogic.tsx
+++ b/apps/backoffice-v2/src/pages/Statistics/hooks/useStatisticsLogic.tsx
@@ -1,0 +1,50 @@
+import { useZodSearchParams } from '@/common/hooks/useZodSearchParams/useZodSearchParams';
+import { useAuthenticatedUserQuery } from '@/domains/auth/hooks/queries/useAuthenticatedUserQuery/useAuthenticatedUserQuery';
+import { useBusinessReportMetricsQuery } from '@/domains/business-reports/hooks/queries/useBusinessReportMetricsQuery/useBusinessReportMetricsQuery';
+import dayjs from 'dayjs';
+import { useState } from 'react';
+import { z } from 'zod';
+
+export const useStatisticsLogic = () => {
+  const { data: userData } = useAuthenticatedUserQuery();
+  const registrationDate = new Date(userData?.user?.registrationDate ?? '1970-01-01');
+
+  const StatisticsSearchSchema = z.object({
+    from: z.string().transform(data => {
+      const dayjsDate = dayjs(data, 'YYYY-MM-DD', true);
+
+      return dayjsDate.isValid() &&
+        dayjsDate.isBefore(dayjs()) &&
+        dayjsDate.date() === 1 &&
+        dayjsDate.add(1, 'day').isAfter(dayjs(registrationDate).startOf('month'))
+        ? data
+        : dayjs().startOf('month').format('YYYY-MM-DD');
+    }),
+  });
+
+  const [{ from }, setSearchParams] = useZodSearchParams(StatisticsSearchSchema);
+  const [date, setDate] = useState<string | undefined>(from ?? undefined);
+  const { data, isLoading, error } = useBusinessReportMetricsQuery({
+    from: date,
+    to: dayjs(date).add(1, 'month').format('YYYY-MM-DD'),
+  });
+
+  const handleDateChange = (newDate: Date) => {
+    const formattedDate = dayjs(newDate).startOf('month').format('YYYY-MM-DD');
+    const result = StatisticsSearchSchema.safeParse({ from: formattedDate });
+
+    if (result.success) {
+      setSearchParams({ from: result.data.from });
+      setDate(result.data.from);
+    }
+  };
+
+  return {
+    data,
+    isLoading,
+    error,
+    date: dayjs(date).toDate(),
+    setDate: handleDateChange,
+    registrationDate,
+  };
+};

--- a/services/workflows-service/src/auth/session-serializer.ts
+++ b/services/workflows-service/src/auth/session-serializer.ts
@@ -46,14 +46,15 @@ export class SessionSerializer extends PassportSerializer {
           firstName: true,
           lastName: true,
           avatarUrl: true,
+          createdAt: true,
           lastActiveAt: true,
           userToProjects: { select: { projectId: true } },
         },
       });
 
-      const { userToProjects, ...userData } = userResult;
+      const { userToProjects, createdAt, ...userData } = userResult;
       const authenticatedEntity = {
-        user: userData,
+        user: { ...userData, registrationDate: createdAt },
         projectIds: userToProjects?.map(userToProject => userToProject.projectId) || null,
         type: 'user',
       } as AuthenticatedEntity & { projectIds: string[] | null };

--- a/services/workflows-service/src/business-report/business-report.controller.external.ts
+++ b/services/workflows-service/src/business-report/business-report.controller.external.ts
@@ -38,7 +38,11 @@ import { PrismaService } from '@/prisma/prisma.service';
 import { AdminAuthGuard } from '@/common/guards/admin-auth.guard';
 import { BusinessReportFindingsListResponseDto } from '@/business-report/dtos/business-report-findings.dto';
 import { MerchantMonitoringClient } from '@/business-report/merchant-monitoring-client';
-import { BusinessReportMetricsDto } from './dtos/business-report-metrics-dto';
+import { BusinessReportMetricsDto } from '@/business-report/dtos/business-report-metrics-dto';
+import {
+  BusinessReportMetricsRequestQueryDto,
+  BusinessReportsMetricsQuerySchema,
+} from '@/business-report/dtos/business-report-metrics.dto';
 
 @ApiBearerAuth()
 @swagger.ApiTags('Business Reports')
@@ -119,10 +123,14 @@ export class BusinessReportControllerExternal {
   @common.Get('/metrics')
   @swagger.ApiOkResponse({ type: BusinessReportMetricsDto })
   @swagger.ApiForbiddenResponse({ type: errors.ForbiddenException })
-  async getMetrics(@CurrentProject() currentProjectId: TProjectId) {
+  @common.UsePipes(new ZodValidationPipe(BusinessReportsMetricsQuerySchema, 'query'))
+  async getMetrics(
+    @CurrentProject() currentProjectId: TProjectId,
+    @Query() { from, to }: BusinessReportMetricsRequestQueryDto,
+  ) {
     const { id: customerId } = await this.customerService.getByProjectId(currentProjectId);
 
-    return await this.merchantMonitoringClient.getMetrics({ customerId });
+    return await this.merchantMonitoringClient.getMetrics({ customerId, from, to });
   }
 
   @common.Post()

--- a/services/workflows-service/src/business-report/dtos/business-report-metrics.dto.ts
+++ b/services/workflows-service/src/business-report/dtos/business-report-metrics.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+import { z } from 'zod';
+
+export class BusinessReportMetricsRequestQueryDto {
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ type: String, required: false })
+  from?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ type: String, required: false })
+  to?: string;
+}
+
+export const BusinessReportsMetricsQuerySchema = z.object({
+  from: z.string().optional(),
+  to: z.string().optional(),
+});

--- a/services/workflows-service/src/business-report/merchant-monitoring-client.ts
+++ b/services/workflows-service/src/business-report/merchant-monitoring-client.ts
@@ -71,6 +71,9 @@ const MetricsResponseSchema = z.object({
       count: z.number(),
     }),
   ),
+  totalActiveMerchants: z.number(),
+  addedMerchantsCount: z.number(),
+  removedMerchantsCount: z.number(),
 });
 
 @Injectable()
@@ -273,10 +276,20 @@ export class MerchantMonitoringClient {
     return response.data ?? [];
   }
 
-  public async getMetrics({ customerId }: { customerId: string }) {
+  public async getMetrics({
+    customerId,
+    from,
+    to,
+  }: {
+    customerId: string;
+    from?: string;
+    to?: string;
+  }) {
     const response = await this.axios.get('merchants/analysis/metrics', {
       params: {
         customerId,
+        from,
+        to,
       },
       headers: {
         Authorization: `Bearer ${env.UNIFIED_API_TOKEN}`,


### PR DESCRIPTION
## Changes

- Adds month-based filter to the statistics page to display relevant data.
- Adds 3 additional metrics showing merchant-related data
- Currently the `to` param is hardcoded to be +1 month from the `from` date, but I added it just in case we add more time-based filters later so that it's easier to convert it to a stateful variable that can change based on user input

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/6a7f23c2-da14-484b-b578-a89ed19eb479" />

<img width="1176" alt="image" src="https://github.com/user-attachments/assets/371802de-b87a-4bc6-b0c3-86652febc7e6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added portfolio analytics with merchant statistics.
	- Introduced month picker for date selection.
	- Enhanced business report metrics with new merchant-related data.

- **Improvements**
	- Updated user schema to include registration and last active dates.
	- Improved metrics querying with optional date range filtering.

- **Refactor**
	- Removed date range functionality from home logic.
	- Updated type definitions for better type safety.
	- Revised component structure for improved layout and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->