### PR TITLE
fix: replaced source of country codes

### DIFF
--- a/apps/kyb-app/src/helpers/countries-data.ts
+++ b/apps/kyb-app/src/helpers/countries-data.ts
@@ -1,9 +1,10 @@
+import { countryCodes } from '@ballerine/common';
+import { State } from 'country-state-city';
 import isoCountries from 'i18n-iso-countries';
 import enCountries from 'i18n-iso-countries/langs/en.json';
 import cnCountries from 'i18n-iso-countries/langs/zh.json';
 import nationalities from 'i18n-nationality';
 import enNationalities from 'i18n-nationality/langs/en.json';
-import { State } from 'country-state-city';
 import { TFunction } from 'i18next';
 
 isoCountries.registerLocale(enCountries);
@@ -21,11 +22,10 @@ const unsupportedNationalities = {
 
 export const getCountries = (lang = 'en') => {
   const language = languageConversionMap[lang as keyof typeof languageConversionMap] ?? lang;
-  const countries = isoCountries.getNames(language, { select: 'official' });
 
-  return Object.entries(countries).map(([isoCode, title]) => ({
+  return countryCodes.map(isoCode => ({
     const: isoCode,
-    title,
+    title: isoCountries.getName(isoCode?.toLocaleUpperCase(), language),
   }));
 };
 


### PR DESCRIPTION
- replaced country codes source to `ballerine/common` in order to ensure that single source of country codes is used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated country data retrieval method in `getCountries` function
	- Improved country code mapping and title generation
	- Streamlined import statements for country-related utilities

The changes primarily focus on optimizing how country information is processed and retrieved, with minimal impact on the overall functionality of the existing methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->