### PR TITLE
feat: add a report note when monitoring status is toggled (BAL-3398)

### DIFF
--- a/apps/backoffice-v2/src/domains/notes/hooks/mutations/useCreateNoteMutation/useCreateNoteMutation.tsx
+++ b/apps/backoffice-v2/src/domains/notes/hooks/mutations/useCreateNoteMutation/useCreateNoteMutation.tsx
@@ -9,8 +9,10 @@ import { TNoteableType } from '@/domains/notes/types';
 
 export const useCreateNoteMutation = ({
   onSuccess,
+  disableToast = false,
 }: {
   onSuccess?: <TData>(data: TData) => void;
+  disableToast: boolean;
 }) => {
   const queryClient = useQueryClient();
 
@@ -41,7 +43,9 @@ export const useCreateNoteMutation = ({
     onSuccess: data => {
       void queryClient.invalidateQueries();
 
-      toast.success(t(`toast:note_created.success`));
+      if (!disableToast) {
+        toast.success(t(`toast:note_created.success`));
+      }
 
       onSuccess?.(data);
     },

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/MerchantMonitoringBusinessReport.page.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/MerchantMonitoringBusinessReport.page.tsx
@@ -223,15 +223,12 @@ export const MerchantMonitoringBusinessReport: FunctionComponent = () => {
                         throw new Error('Merchant ID is missing');
                       }
 
-                      turnOngoingMonitoringOn(
-                        { merchantId: businessReport.merchantId },
-                        {
-                          onSuccess: () => {
-                            setIsDeboardModalOpen(false);
-                            setIsDropdownOpen(false);
-                          },
+                      turnOngoingMonitoringOn(businessReport.merchantId, {
+                        onSuccess: () => {
+                          setIsDeboardModalOpen(false);
+                          setIsDropdownOpen(false);
                         },
-                      );
+                      });
                     }}
                     variant={'ghost'}
                     className="justify-start"

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/MerchantMonitoringBusinessReport.page.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/MerchantMonitoringBusinessReport.page.tsx
@@ -171,10 +171,10 @@ export const MerchantMonitoringBusinessReport: FunctionComponent = () => {
                                 </FormControl>
                                 <FormMessage />
                                 <SelectContent>
-                                  {deboardingReasonOptions?.map(({ label, value }, index) => {
+                                  {deboardingReasonOptions?.map((option, index) => {
                                     return (
-                                      <SelectItem key={index} value={value}>
-                                        {label}
+                                      <SelectItem key={index} value={option}>
+                                        {option}
                                       </SelectItem>
                                     );
                                   })}

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/fetchers.ts
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/fetchers.ts
@@ -7,8 +7,6 @@ import { handleZodError } from '@/common/utils/handle-zod-error/handle-zod-error
 export type TurnOngoingMonitoringBody = z.infer<typeof TurnOngoingMonitoringBodySchema>;
 export const TurnOngoingMonitoringBodySchema = z.object({
   state: z.string(),
-  reason: z.string().optional(),
-  userReason: z.string().optional(),
 });
 
 export type TurnOngoingMonitoringResponse = z.infer<typeof TurnOngoingMonitoringResponseSchema>;

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useMerchantMonitoringBusinessReportLogic/useMerchantMonitoringBusinessReportLogic.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useMerchantMonitoringBusinessReportLogic/useMerchantMonitoringBusinessReportLogic.tsx
@@ -1,5 +1,6 @@
 import { ParsedBooleanSchema, useReportTabs } from '@ballerine/ui';
 import { t } from 'i18next';
+import { capitalize } from 'lodash-es';
 import { useCallback, useMemo } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -15,6 +16,7 @@ import {
   MERCHANT_REPORT_TYPES_MAP,
 } from '@/domains/business-reports/constants';
 import { useBusinessReportByIdQuery } from '@/domains/business-reports/hooks/queries/useBusinessReportByIdQuery/useBusinessReportByIdQuery';
+import { useCreateNoteMutation } from '@/domains/notes/hooks/mutations/useCreateNoteMutation/useCreateNoteMutation';
 import { useNotesByNoteable } from '@/domains/notes/hooks/queries/useNotesByNoteable/useNotesByNoteable';
 import { useToggleMonitoringMutation } from '@/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation';
 import { isObject } from '@ballerine/common';
@@ -56,11 +58,11 @@ const statusToBadgeData = {
 } as const;
 
 const deboardingReasonOptions = [
-  { value: 'fraud', label: 'Fraudulent Activity Detected' },
-  { value: 'regulations', label: 'Non-Compliance with Regulations' },
-  { value: 'disputes', label: 'Excessive Chargebacks or Disputes' },
-  { value: 'expired', label: 'Business Relationship Ended' },
-  { value: 'other', label: 'Other' },
+  'Fraudulent Activity Detected',
+  'Non-Compliance with Regulations',
+  'Excessive Chargebacks or Disputes',
+  'Business Relationship Ended',
+  'Other',
 ] as const;
 
 export const useMerchantMonitoringBusinessReportLogic = () => {
@@ -95,9 +97,18 @@ export const useMerchantMonitoringBusinessReportLogic = () => {
     return turnOffMonitoringMutation.mutate({ merchantId: businessReport.merchantId, body: data });
   };
 
+  const { mutateAsync: mutateCreateNote } = useCreateNoteMutation({ disableToast: true });
   const turnOnMonitoringMutation = useToggleMonitoringMutation({
     state: 'on',
     onSuccess: () => {
+      void mutateCreateNote({
+        content: 'Monitoring turned on',
+        entityId: businessReport?.merchantId ?? '',
+        entityType: 'Business',
+        noteableId: businessReport?.id ?? '',
+        noteableType: 'Report',
+        parentNoteId: null,
+      });
       toast.success(t(`toast:business_monitoring_on.success`));
     },
     onError: error => {
@@ -112,6 +123,22 @@ export const useMerchantMonitoringBusinessReportLogic = () => {
   const turnOffMonitoringMutation = useToggleMonitoringMutation({
     state: 'off',
     onSuccess: () => {
+      const { reason, userReason } = form.getValues();
+      const content = [
+        'Monitoring turned off',
+        reason ? `with reason: ${capitalize(reason)}` : null,
+        userReason ? `(${userReason})` : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+      void mutateCreateNote({
+        content,
+        entityId: businessReport?.merchantId ?? '',
+        entityType: 'Business',
+        noteableId: businessReport?.id ?? '',
+        noteableType: 'Report',
+        parentNoteId: null,
+      });
       setIsDeboardModalOpen(false);
       setIsDropdownOpen(false);
       form.reset();

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useMerchantMonitoringBusinessReportLogic/useMerchantMonitoringBusinessReportLogic.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useMerchantMonitoringBusinessReportLogic/useMerchantMonitoringBusinessReportLogic.tsx
@@ -94,7 +94,7 @@ export const useMerchantMonitoringBusinessReportLogic = () => {
       throw new Error('Merchant ID is missing');
     }
 
-    return turnOffMonitoringMutation.mutate({ merchantId: businessReport.merchantId, body: data });
+    return turnOffMonitoringMutation.mutate(businessReport.merchantId);
   };
 
   const { mutateAsync: mutateCreateNote } = useCreateNoteMutation({ disableToast: true });

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation.tsx
@@ -2,10 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { HttpError } from '@/common/errors/http-error';
-import {
-  turnOngoingMonitoring,
-  TurnOngoingMonitoringBody,
-} from '@/pages/MerchantMonitoringBusinessReport/fetchers';
+import { turnOngoingMonitoring } from '@/pages/MerchantMonitoringBusinessReport/fetchers';
 
 export const useToggleMonitoringMutation = ({
   state,
@@ -19,10 +16,8 @@ export const useToggleMonitoringMutation = ({
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (data: {
-      merchantId: string;
-      body?: Omit<TurnOngoingMonitoringBody, 'state'>;
-    }) => turnOngoingMonitoring({ merchantId: data.merchantId, body: { ...data.body, state } }),
+    mutationFn: async (merchantId: string) =>
+      turnOngoingMonitoring({ merchantId, body: { state } }),
     onSuccess: data => {
       void queryClient.invalidateQueries();
 

--- a/services/workflows-service/src/business/business.controller.external.ts
+++ b/services/workflows-service/src/business/business.controller.external.ts
@@ -160,8 +160,6 @@ export class BusinessControllerExternal {
       featureConfig: {
         [FEATURE_LIST.ONGOING_MERCHANT_REPORT]: {
           enabled: isEnabled,
-          reason: data.reason ?? null,
-          userReason: data.userReason ?? null,
           disabledAt: isEnabled ? null : new Date().getTime(),
         },
       },

--- a/services/workflows-service/src/business/dtos/business-monitoring.patch.dto.ts
+++ b/services/workflows-service/src/business/dtos/business-monitoring.patch.dto.ts
@@ -1,19 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsIn, IsOptional, IsString } from 'class-validator';
+import { IsIn, IsString } from 'class-validator';
 
 export class BusinessMonitoringPatchDto {
   @ApiProperty({ type: String, required: true })
   @IsString()
   @IsIn(['on', 'off'])
   state!: 'on' | 'off';
-
-  @ApiProperty({ type: String, required: false })
-  @IsOptional()
-  @IsString()
-  reason?: string;
-
-  @ApiProperty({ type: String, required: false })
-  @IsOptional()
-  @IsString()
-  userReason?: string;
 }


### PR DESCRIPTION
Stop storing reason & userReason inside metadata, instead create a note on a report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added option to disable toast notifications when creating notes
	- Simplified ongoing monitoring state management
	- Enhanced note creation for monitoring state changes

- **Bug Fixes**
	- Streamlined merchant monitoring business report logic
	- Removed unnecessary optional parameters in monitoring state updates

- **Refactor**
	- Simplified function calls and data structures
	- Removed redundant properties from data transfer objects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->