### PR TITLE
fix: fixed final submission failure without directors and ubos

### DIFF
--- a/services/workflows-service/src/collection-flow/controllers/collection-flow.controller.ts
+++ b/services/workflows-service/src/collection-flow/controllers/collection-flow.controller.ts
@@ -167,7 +167,7 @@ export class CollectionFlowController {
               ...director,
             };
           },
-        ),
+        ) || [],
       );
 
       const ubos = await Promise.all(
@@ -187,7 +187,7 @@ export class CollectionFlowController {
               ...ubo,
             };
           },
-        ),
+        ) || [],
       );
 
       await this.workflowService.event(
@@ -199,8 +199,8 @@ export class CollectionFlowController {
               entity: {
                 data: {
                   additionalInfo: {
-                    directors,
-                    ubos,
+                    directors: directors?.length ? directors : undefined,
+                    ubos: ubos?.length ? ubos : undefined,
                   },
                 },
               },


### PR DESCRIPTION
Fixes bug when final-submission fails on flows that doesnt have directors or ubos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty director and UBO arrays during workflow submission
	- Prevented sending empty arrays in payload, setting them to `undefined` when appropriate

<!-- end of auto-generated comment: release notes by coderabbit.ai -->