### PR TITLE
Illiar/feat/kyb v1 cleanup

### DIFF
--- a/apps/kyb-app/CHANGELOG.md
+++ b/apps/kyb-app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # kyb-app
 
+## 0.3.118
+
+### Patch Changes
+
+- Updated dependencies
+  - @ballerine/ui@0.5.69
+
 ## 0.3.117
 
 ### Patch Changes

--- a/apps/kyb-app/package.json
+++ b/apps/kyb-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/kyb-app",
   "private": true,
-  "version": "0.3.117",
+  "version": "0.3.118",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -19,7 +19,7 @@
     "@ballerine/blocks": "0.2.34",
     "@ballerine/common": "^0.9.70",
     "@ballerine/workflow-browser-sdk": "0.6.89",
-    "@ballerine/ui": "0.5.68",
+    "@ballerine/ui": "0.5.69",
     "@lukemorales/query-key-factory": "^1.0.3",
     "@radix-ui/react-icons": "^1.3.0",
     "@rjsf/core": "^5.9.0",

--- a/apps/kyb-app/src/components/organisms/DynamicUI/Page/hooks/usePageErrors/usePageErrors.ts
+++ b/apps/kyb-app/src/components/organisms/DynamicUI/Page/hooks/usePageErrors/usePageErrors.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import { ErrorField } from '@/components/organisms/DynamicUI/rule-engines';
 import { findDocumentDefinitionById } from '@/components/organisms/UIRenderer/elements/JSONForm/helpers/findDefinitionByName';
 import { Document, UIElement, UIPage } from '@/domains/collection-flow';

--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/components/CheckboxList/CheckboxList.tsx
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/components/CheckboxList/CheckboxList.tsx
@@ -7,7 +7,6 @@ interface CheckboxListOption {
 }
 
 export const CheckboxList = (props: WithTestId<RJSFInputProps>) => {
-  //@ts-nocheck
   const { uiSchema, formData = [], onChange, disabled, testId } = props;
 
   const options = useMemo(() => {

--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/components/DocumentField/DocumentField.tsx
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/components/DocumentField/DocumentField.tsx
@@ -17,6 +17,7 @@ import { HTTPError } from 'ky';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { DocumentValueDestinationParser } from './helpers/document-value-destination-parser';
 import { serializeDocumentId } from './helpers/serialize-document-id';
 
 export interface DocumentFieldParams {
@@ -69,12 +70,10 @@ export const DocumentField = (
   const fileId = useMemo(() => {
     if (!Array.isArray(payload.documents)) return null;
 
-    //@ts-ignore
-    const parser = new DocumentValueDestinationParser(definition.valueDestination);
+    const parser = new DocumentValueDestinationParser(definition.valueDestination!);
     const documentsPath = parser.extractRootPath();
     const documentPagePath = parser.extractPagePath();
-    //@ts-ignore
-    const documents = (get(payload, documentsPath) as Document[]) || [];
+    const documents = (get(payload, documentsPath!) as Document[]) || [];
 
     const document = documents.find((document: Document) => {
       //@ts-ignore

--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/components/Multiselect/Multiselect.tsx
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/components/Multiselect/Multiselect.tsx
@@ -29,7 +29,7 @@ export const Multiselect = ({
           className="h-6"
           variant={definition?.options.variants?.chip?.wrapper}
         >
-          <Chip.Label text={option?.label} variant={definition?.options.variants?.chip?.label} />
+          <Chip.Label text={option?.title} variant={definition?.options.variants?.chip?.label} />
           <Chip.UnselectButton
             {...params.unselectButtonProps}
             icon={<X className="hover:text-muted-foreground h-3 w-3 text-white" />}

--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/components/Multiselect/Multiselect.tsx
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/components/Multiselect/Multiselect.tsx
@@ -1,4 +1,3 @@
-//@ts-nocheck
 import { UIElement } from '@/domains/collection-flow';
 import {
   Chip,
@@ -30,7 +29,7 @@ export const Multiselect = ({
           className="h-6"
           variant={definition?.options.variants?.chip?.wrapper}
         >
-          <Chip.Label text={option?.title} variant={definition?.options.variants?.chip?.label} />
+          <Chip.Label text={option?.label} variant={definition?.options.variants?.chip?.label} />
           <Chip.UnselectButton
             {...params.unselectButtonProps}
             icon={<X className="hover:text-muted-foreground h-3 w-3 text-white" />}

--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/json-form.fields.ts
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/JSONForm/json-form.fields.ts
@@ -1,4 +1,3 @@
-//@ts-nocheck
 import { CheckboxList } from '@/components/organisms/UIRenderer/elements/JSONForm/components/CheckboxList';
 import { CountryPicker } from '@/components/organisms/UIRenderer/elements/JSONForm/components/CountryPicker';
 import { DocumentField } from '@/components/organisms/UIRenderer/elements/JSONForm/components/DocumentField';

--- a/apps/kyb-app/src/components/organisms/UIRenderer/elements/SubmitButton/helpers.ts
+++ b/apps/kyb-app/src/components/organisms/UIRenderer/elements/SubmitButton/helpers.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import { ARRAY_VALUE_INDEX_PLACEHOLDER } from '@/common/consts/consts';
 import { DocumentFieldParams } from '@/components/organisms/UIRenderer/elements/JSONForm/components/DocumentField';
 import { UIElement, UIPage } from '@/domains/collection-flow';

--- a/packages/react-pdf-toolkit/CHANGELOG.md
+++ b/packages/react-pdf-toolkit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ballerine/react-pdf-toolkit
 
+## 1.2.69
+
+### Patch Changes
+
+- Updated dependencies
+  - @ballerine/ui@0.5.69
+
 ## 1.2.68
 
 ### Patch Changes

--- a/packages/react-pdf-toolkit/package.json
+++ b/packages/react-pdf-toolkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/react-pdf-toolkit",
   "private": false,
-  "version": "1.2.68",
+  "version": "1.2.69",
   "types": "./dist/build.d.ts",
   "main": "./dist/react-pdf-toolkit.js",
   "module": "./dist/react-pdf-toolkit.mjs",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@ballerine/config": "^1.1.32",
-    "@ballerine/ui": "0.5.68",
+    "@ballerine/ui": "0.5.69",
     "@react-pdf/renderer": "^3.1.14",
     "@sinclair/typebox": "^0.31.7",
     "ajv": "^8.12.0",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ballerine/ui
 
+## 0.5.69
+
+### Patch Changes
+
+- Fixed options mapping at Multiselect
+
 ## 0.5.68
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ballerine/ui",
   "private": false,
-  "version": "0.5.68",
+  "version": "0.5.69",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/src/components/molecules/inputs/MultiSelect/MultiSelect.stories.tsx
+++ b/packages/ui/src/components/molecules/inputs/MultiSelect/MultiSelect.stories.tsx
@@ -9,7 +9,7 @@ export default {
 
 const options = new Array(20)
   .fill(null)
-  .map((_, index) => ({ value: `item-${index}`, label: `Item-${index}` }));
+  .map((_, index) => ({ value: `item-${index}`, title: `Item-${index}` }));
 
 const DefaultComponent = () => {
   const [value, setValue] = useState<MultiSelectValue[]>([]);
@@ -17,7 +17,7 @@ const DefaultComponent = () => {
   const renderSelected: MultiSelectSelectedItemRenderer = useCallback((params, option) => {
     return (
       <Chip key={option.value} className="h-6">
-        <Chip.Label text={option.label} variant="secondary" />
+        <Chip.Label text={option.title} variant="secondary" />
         <Chip.UnselectButton
           {...params.unselectButtonProps}
           icon={<X className="hover:text-muted-foreground h-3 w-3 text-white" />}
@@ -46,7 +46,7 @@ const DisabledComponent = () => {
   const renderSelected: MultiSelectSelectedItemRenderer = useCallback((params, option) => {
     return (
       <Chip key={option.value} className="h-6">
-        <Chip.Label text={option.label} variant="secondary" />
+        <Chip.Label text={option.title} variant="secondary" />
         <Chip.UnselectButton
           {...params.unselectButtonProps}
           icon={<X className="hover:text-muted-foreground h-3 w-3 text-white" />}

--- a/packages/ui/src/components/molecules/inputs/MultiSelect/MultiSelect.tsx
+++ b/packages/ui/src/components/molecules/inputs/MultiSelect/MultiSelect.tsx
@@ -10,7 +10,7 @@ import { FocusEvent, useCallback, useMemo, useRef, useState } from 'react';
 export type MultiSelectValue = string | number;
 
 export interface MultiSelectOption {
-  label: string;
+  title: string;
   value: MultiSelectValue;
 }
 
@@ -118,7 +118,7 @@ export const MultiSelect = ({
       .filter(option => !selectedMap[option.value as Exclude<PropertyKey, symbol>])
       .filter(option =>
         inputValue
-          ? option.label?.toLocaleLowerCase().includes(inputValue.toLocaleLowerCase())
+          ? option.title?.toLocaleLowerCase().includes(inputValue.toLocaleLowerCase())
           : true,
       );
   }, [options, selected, inputValue]);
@@ -203,7 +203,7 @@ export const MultiSelect = ({
                         className={'cursor-pointer'}
                         data-testid={testId ? `${testId}-option` : undefined}
                       >
-                        {option.label}
+                        {option.title}
                       </CommandItem>
                     );
                   })}

--- a/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/MultiselectInputAdapter/MultiselectInputAdapter.tsx
+++ b/packages/ui/src/components/organisms/DynamicForm/components/RSJVInputAdaters/MultiselectInputAdapter/MultiselectInputAdapter.tsx
@@ -45,7 +45,7 @@ export const MultiselectInputAdapter: RJSFInputAdapter<MultiSelectValue[], Multi
     const defaultRenderer: MultiSelectSelectedItemRenderer = (params, option) => {
       return (
         <Chip key={option.value} className="h-6">
-          <Chip.Label text={option.label} variant="secondary" />
+          <Chip.Label text={option.title} variant="secondary" />
           <Chip.UnselectButton
             {...params.unselectButtonProps}
             icon={<X className="hover:text-muted-foreground h-3 w-3 text-white" />}

--- a/packages/ui/src/components/organisms/Form/DynamicForm/fields/MultiselectField/MultiselectField.tsx
+++ b/packages/ui/src/components/organisms/Form/DynamicForm/fields/MultiselectField/MultiselectField.tsx
@@ -1,6 +1,6 @@
 import { MultiSelect, MultiSelectOption, MultiSelectValue } from '@/components/molecules';
 import { SelectedElementParams } from '@/components/molecules/inputs/MultiSelect/types';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useField } from '../../hooks/external';
 import { useMountEvent } from '../../hooks/internal/useMountEvent';
 import { useUnmountEvent } from '../../hooks/internal/useUnmountEvent';
@@ -12,8 +12,13 @@ import { TDynamicFormField } from '../../types';
 import { useStack } from '../FieldList/providers/StackProvider';
 import { MultiselectfieldSelectedItem } from './MultiselectFieldSelectedItem';
 
+export interface MultiselectFieldOption {
+  label: string;
+  value: any;
+}
+
 export interface IMultiselectFieldParams {
-  options: MultiSelectOption[];
+  options: MultiselectFieldOption[];
 }
 
 export const MultiselectField: TDynamicFormField<IMultiselectFieldParams> = ({ element }) => {
@@ -25,6 +30,12 @@ export const MultiselectField: TDynamicFormField<IMultiselectFieldParams> = ({ e
     element,
     stack,
   );
+
+  const multiselectOptions = useMemo(() => {
+    return (
+      element.params?.options?.map(option => ({ title: option.label, value: option.value })) || []
+    );
+  }, [element.params?.options]);
 
   const renderSelected = useCallback((params: SelectedElementParams, option: MultiSelectOption) => {
     return <MultiselectfieldSelectedItem option={option} params={params} />;
@@ -45,7 +56,7 @@ export const MultiselectField: TDynamicFormField<IMultiselectFieldParams> = ({ e
         onChange={handleChange}
         onBlur={onBlur}
         onFocus={onFocus}
-        options={element.params?.options || []}
+        options={multiselectOptions}
         renderSelected={renderSelected}
       />
       <FieldDescription element={element} />

--- a/packages/ui/src/components/organisms/Form/DynamicForm/fields/MultiselectField/MultiselectField.unit.test.tsx
+++ b/packages/ui/src/components/organisms/Form/DynamicForm/fields/MultiselectField/MultiselectField.unit.test.tsx
@@ -12,7 +12,11 @@ import { FieldErrors } from '../../layouts/FieldErrors';
 import { FieldLayout } from '../../layouts/FieldLayout';
 import { IFormElement } from '../../types';
 import { useStack } from '../FieldList/providers/StackProvider';
-import { IMultiselectFieldParams, MultiselectField } from './MultiselectField';
+import {
+  IMultiselectFieldParams,
+  MultiselectField,
+  MultiselectFieldOption,
+} from './MultiselectField';
 import { MultiselectfieldSelectedItem } from './MultiselectFieldSelectedItem';
 
 vi.mock('./MultiselectFieldSelectedItem', () => ({
@@ -77,7 +81,7 @@ vi.mock('../FieldList/providers/StackProvider', () => ({
 }));
 
 describe('MultiselectField', () => {
-  const mockOptions: MultiSelectOption[] = [
+  const mockOptions: MultiselectFieldOption[] = [
     { label: 'Option 1', value: 'opt1' },
     { label: 'Option 2', value: 'opt2' },
     { label: 'Option 3', value: 'opt3' },
@@ -141,7 +145,9 @@ describe('MultiselectField', () => {
     const multiselect = vi.mocked(MultiSelect).mock.calls[0]![0];
     expect(multiselect.value).toEqual(['opt1']);
     expect(multiselect.disabled).toBe(false);
-    expect(multiselect.options).toEqual(mockOptions);
+    expect(multiselect.options).toEqual(
+      mockOptions.map(option => ({ title: option.label, value: option.value })),
+    );
     expect(multiselect.onBlur).toBe(mockOnBlur);
     expect(multiselect.onFocus).toBe(mockOnFocus);
   });
@@ -186,7 +192,7 @@ describe('MultiselectField', () => {
 
     const multiselect = vi.mocked(MultiSelect).mock.calls[0]![0];
     const mockParams: SelectedElementParams = { unselectButtonProps: { onClick: vi.fn() } as any };
-    const mockOption: MultiSelectOption = { label: 'Test', value: 'test' };
+    const mockOption: MultiSelectOption = { title: 'Test', value: 'test' };
 
     const result = multiselect.renderSelected(mockParams, mockOption);
     expect(result.type).toBe(MultiselectfieldSelectedItem);

--- a/packages/ui/src/components/organisms/Form/DynamicForm/fields/MultiselectField/MultiselectFieldSelectedItem.tsx
+++ b/packages/ui/src/components/organisms/Form/DynamicForm/fields/MultiselectField/MultiselectFieldSelectedItem.tsx
@@ -13,7 +13,7 @@ export const MultiselectfieldSelectedItem: FunctionComponent<
 > = ({ option, params }) => {
   return (
     <Chip key={option.value} className="h-6">
-      <Chip.Label text={option.label} variant="secondary" />
+      <Chip.Label text={option.title} variant="secondary" />
       <Chip.UnselectButton
         {...params.unselectButtonProps}
         icon={<X className="hover:text-muted-foreground h-3 w-3 text-white" />}

--- a/packages/ui/src/components/organisms/Form/DynamicForm/fields/MultiselectField/MultiselectFieldSelectedItem.unit.test.tsx
+++ b/packages/ui/src/components/organisms/Form/DynamicForm/fields/MultiselectField/MultiselectFieldSelectedItem.unit.test.tsx
@@ -1,4 +1,4 @@
-import { MultiSelectOption } from '@/components/molecules/inputs/MultiSelect';
+import { MultiSelectOption } from '@/components/molecules';
 import { SelectedElementParams } from '@/components/molecules/inputs/MultiSelect/types';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -6,7 +6,7 @@ import { MultiselectfieldSelectedItem } from './MultiselectFieldSelectedItem';
 
 describe('MultiselectfieldSelectedItem', () => {
   const mockOption: MultiSelectOption = {
-    label: 'Test Option',
+    title: 'Test Option',
     value: 'test-value',
   };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,7 +536,7 @@ importers:
         specifier: ^0.9.70
         version: link:../../packages/common
       '@ballerine/ui':
-        specifier: 0.5.68
+        specifier: 0.5.69
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
         specifier: 0.6.89
@@ -1519,7 +1519,7 @@ importers:
         specifier: ^1.1.32
         version: link:../config
       '@ballerine/ui':
-        specifier: 0.5.68
+        specifier: 0.5.69
         version: link:../ui
       '@react-pdf/renderer':
         specifier: ^3.1.14


### PR DESCRIPTION
- Fixed crash caused by documents destination parser
- Fixed multiselect options mapping caused by conflict with v2
- removed ts tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Updates**
	- Updated `@ballerine/ui` from version `0.5.68` to `0.5.69` across multiple packages
	- Updated package versions for `kyb-app` and `react-pdf-toolkit`

- **Code Quality**
	- Removed TypeScript ignore comments in multiple files, enabling stricter type checking
	- Improved type safety in various components

- **Component Improvements**
	- Modified MultiSelect component to use `title` instead of `label` for option display
	- Introduced a new interface for options in the MultiselectField component, enhancing type safety and structure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->