### PR TITLE
fix(alerts): use correct businessIds to seed transaction alerts #2727

### DIFF
--- a/services/workflows-service/scripts/seed.ts
+++ b/services/workflows-service/scripts/seed.ts
@@ -1009,7 +1009,7 @@ async function seed() {
 
   await seedTransactionsAlerts(client, {
     project: project1,
-    businessIds: businessRiskIds,
+    businessIds: businessIds,
     counterpartyIds: ids1
       .map(
         ({ counterpartyOriginatorId, counterpartyBeneficiaryId }) =>


### PR DESCRIPTION
Replace businessRiskIds with businessIds  
Incorrect businessRiskIds were used when seeding transaction alerts, causing issues as they didn't exist at the time of adding alerts. Fixed by using the correct businessIds."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the business data used during transaction alert generation to ensure users receive accurate and consistent alert information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->