### PR TITLE
BAL-3674: Warning Icon & Priority field color update

### DIFF
--- a/packages/ui/src/components/organisms/Form/DynamicForm/fields/FileField/hooks/useFileUpload/useFileUpload.ts
+++ b/packages/ui/src/components/organisms/Form/DynamicForm/fields/FileField/hooks/useFileUpload/useFileUpload.ts
@@ -7,6 +7,7 @@ import { useElement, useField } from '../../../../hooks/external';
 import { useTaskRunner } from '../../../../providers/TaskRunner/hooks/useTaskRunner';
 import { ITask } from '../../../../providers/TaskRunner/types';
 import { IFormElement } from '../../../../types';
+import { DEFAULT_CREATION_PARAMS } from '../../../DocumentField/defaults';
 import { useStack } from '../../../FieldList/providers/StackProvider';
 import { IFileFieldParams } from '../../FileField';
 
@@ -20,7 +21,10 @@ export const useFileUpload = (
   const { addTask, removeTask } = useTaskRunner();
   const { metadata } = useDynamicForm();
 
-  const { run, isLoading } = useHttp(element.params!.httpParams!.createDocument || {}, metadata);
+  const { run, isLoading } = useHttp(
+    element.params?.httpParams?.createDocument || DEFAULT_CREATION_PARAMS,
+    metadata,
+  );
 
   const { onChange } = useField(element);
 

--- a/packages/ui/src/components/organisms/Form/DynamicForm/layouts/FieldPriorityReason/FieldPriorityReason.tsx
+++ b/packages/ui/src/components/organisms/Form/DynamicForm/layouts/FieldPriorityReason/FieldPriorityReason.tsx
@@ -1,4 +1,5 @@
 import { createTestId } from '@/components/organisms/Renderer';
+import { InfoIcon } from 'lucide-react';
 import { useStack } from '../../fields/FieldList/providers/StackProvider';
 import { usePriorityFields } from '../../hooks/internal/usePriorityFields';
 import { IFormElement } from '../../types';
@@ -11,14 +12,19 @@ export const FieldPriorityReason: React.FC<IFieldPriorityReasonProps> = ({ eleme
   const { stack } = useStack();
   const { priorityField } = usePriorityFields(element);
 
-  if (!priorityField) return null;
+  if (!priorityField) {
+    return null;
+  }
 
   return (
-    <p
-      className="py-1 text-[0.8rem] text-amber-400"
-      data-testid={`${createTestId(element, stack)}-priority-reason`}
-    >
-      {priorityField.reason}
-    </p>
+    <div className="flex flex-row flex-nowrap items-start gap-2">
+      <InfoIcon size={16} className="text-warning mt-1.5 shrink-0" />
+      <p
+        className="text-warning py-1 text-[0.8rem]"
+        data-testid={`${createTestId(element, stack)}-priority-reason`}
+      >
+        {priorityField.reason}
+      </p>
+    </div>
   );
 };


### PR DESCRIPTION
- Added warning icon before priority reason text
- Changed color of warnings to `text-warning`
- Fixed crash caused by missing params on `filefield`
- Set default params for `filefield`

![image](https://github.com/user-attachments/assets/330bd7db-ebf5-4ae9-871a-cb9818e65418)
![image](https://github.com/user-attachments/assets/0a44f363-6506-4b06-90bf-03e524d200c8)

