### PR TITLE
Give DB more time to come online

### DIFF
--- a/services/workflows-service/package.json
+++ b/services/workflows-service/package.json
@@ -5,7 +5,7 @@
   "description": "workflow-service",
   "scripts": {
     "spellcheck": "cspell \"*\"",
-    "setup": "npm run docker:db:down && npm run docker:db && wait-on tcp:5432 && npm run db:reset && npm run seed",
+    "setup": "npm run docker:db:down && npm run docker:db && echo Waiting 2 seconds for DB to fully start && sleep 2 && npm run db:reset && npm run seed",
     "format": "prettier --write . '!**/*.{md,hbs}'",
     "format:check": "prettier --check . '!**/*.{md,hbs}'",
     "lint": "eslint . --fix",


### PR DESCRIPTION
Added sleep statement for database to fully come online. Without this the migration fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the database initialization process to use a fixed 2-second delay before resetting and seeding, ensuring a smoother startup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->