### PR TITLE
fix(MerchantMonitoringTable): remove duplicate risk indicators

### DIFF
--- a/apps/backoffice-v2/src/common/constants.ts
+++ b/apps/backoffice-v2/src/common/constants.ts
@@ -11,3 +11,4 @@ export const URL_REGEX =
   /((https?):\/\/)?([a-zA-Z0-9-_]+\.)+[a-zA-Z0-9]+(\.[a-z]{2})?(\/[a-zA-Z0-9_#-]+)*(\/)?(\?[a-zA-Z0-9_-]+=[a-zA-Z0-9_-]+(&[a-zA-Z0-9_-]+=[a-zA-Z0-9_-]+)*)?(#[a-zA-Z0-9_-]+)?/;
 
 export const NO_VIOLATION_DETECTED_RISK_INDICATOR_ID = 'no-violation-detected';
+export const POSITIVE_RISK_LEVEL_ID = 'positive';

--- a/apps/backoffice-v2/src/pages/MerchantMonitoring/components/MerchantMonitoringTable/columns.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoring/components/MerchantMonitoringTable/columns.tsx
@@ -162,6 +162,9 @@ export const useColumns = ({ isDemoAccount = false }) => {
             .filter(
               el => el.id !== NO_VIOLATION_DETECTED_RISK_INDICATOR_ID && el.name && el.riskLevel,
             )
+            .filter(
+              (violation, index, self) => index === self.findIndex(t => t.id === violation.id),
+            )
             .sort((a, b) => {
               return a.riskLevel === b.riskLevel
                 ? (a.name ?? '').localeCompare(b.name ?? '')

--- a/apps/backoffice-v2/src/pages/MerchantMonitoring/components/MerchantMonitoringTable/columns.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoring/components/MerchantMonitoringTable/columns.tsx
@@ -17,7 +17,10 @@ import { titleCase } from 'string-ts';
 
 import { CopyToClipboardButton } from '@/common/components/atoms/CopyToClipboardButton/CopyToClipboardButton';
 import { IndicatorCircle } from '@/common/components/atoms/IndicatorCircle/IndicatorCircle';
-import { NO_VIOLATION_DETECTED_RISK_INDICATOR_ID } from '@/common/constants';
+import {
+  NO_VIOLATION_DETECTED_RISK_INDICATOR_ID,
+  POSITIVE_RISK_LEVEL_ID,
+} from '@/common/constants';
 import { useEllipsesWithTitle } from '@/common/hooks/useEllipsesWithTitle/useEllipsesWithTitle';
 import { ctw } from '@/common/utils/ctw/ctw';
 import { TBusinessReport } from '@/domains/business-reports/fetchers';
@@ -160,10 +163,12 @@ export const useColumns = ({ isDemoAccount = false }) => {
         cell: ({ row }) => {
           const violations = (row.original.data?.allViolations ?? [])
             .filter(
-              el => el.id !== NO_VIOLATION_DETECTED_RISK_INDICATOR_ID && el.name && el.riskLevel,
-            )
-            .filter(
-              (violation, index, self) => index === self.findIndex(t => t.id === violation.id),
+              (violation, index, self) =>
+                violation.id !== NO_VIOLATION_DETECTED_RISK_INDICATOR_ID &&
+                violation.name &&
+                violation.riskLevel &&
+                violation.riskLevel !== POSITIVE_RISK_LEVEL_ID &&
+                index === self.findIndex(t => t.id === violation.id),
             )
             .sort((a, b) => {
               return a.riskLevel === b.riskLevel


### PR DESCRIPTION
- Implement logic to filter out duplicate violation indicators
- Ensure each indicator is unique based on its ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the monitoring view by filtering out duplicate violations, ensuring only unique entries are displayed for a clearer overview.
	- Updated filtering logic to exclude specific risk levels from the violations displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->