### PR TITLE
fix: use ongoing monitoring flag for unresolved alerts notice

### DIFF
--- a/apps/backoffice-v2/src/pages/Statistics/components/PortfolioRiskStatistics/PortfolioRiskStatistics.tsx
+++ b/apps/backoffice-v2/src/pages/Statistics/components/PortfolioRiskStatistics/PortfolioRiskStatistics.tsx
@@ -36,7 +36,7 @@ export const PortfolioRiskStatistics: FunctionComponent<
     alertedReports,
     from,
     to,
-    isMerchantMonitoringEnabled,
+    isOngoingMonitoringEnabled,
   } = usePortfolioRiskStatisticsLogic({
     userSelectedDate,
     violationCounts,
@@ -159,7 +159,7 @@ export const PortfolioRiskStatistics: FunctionComponent<
             </CardContent>
           </Card>
         </div>
-        {isMerchantMonitoringEnabled && (
+        {isOngoingMonitoringEnabled && (
           <div className={'self-start rounded-xl bg-[#F6F6F6] p-2'}>
             <Card className={'flex h-full flex-col px-3'}>
               <CardHeader className={'pb-2 font-bold'}>Unresolved Monitoring Alerts</CardHeader>

--- a/apps/backoffice-v2/src/pages/Statistics/components/PortfolioRiskStatistics/hooks/usePortfolioRiskStatisticsLogic/usePortfolioRiskStatisticsLogic.tsx
+++ b/apps/backoffice-v2/src/pages/Statistics/components/PortfolioRiskStatistics/hooks/usePortfolioRiskStatisticsLogic/usePortfolioRiskStatisticsLogic.tsx
@@ -62,8 +62,7 @@ export const usePortfolioRiskStatisticsLogic = ({
   });
 
   const alertedReports = businessReports?.totalItems ?? 0;
-  const isMerchantMonitoringEnabled =
-    (customer?.config?.isMerchantMonitoringEnabled && !customer?.config?.isDemoAccount) ?? false;
+  const isOngoingMonitoringEnabled = customer?.config?.isOngoingMonitoringEnabled ?? false;
 
   return {
     riskLevelToFillColor,
@@ -78,6 +77,6 @@ export const usePortfolioRiskStatisticsLogic = ({
     from,
     to,
     alertedReports,
-    isMerchantMonitoringEnabled,
+    isOngoingMonitoringEnabled,
   };
 };


### PR DESCRIPTION
<img width="1154" alt="image" src="https://github.com/user-attachments/assets/aafcb42d-01d1-4f1c-833a-9ab46f65162c" />

<img width="1113" alt="image" src="https://github.com/user-attachments/assets/a16ed0a7-2459-4b60-bb75-6b7f22faa98e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined monitoring logic in the Portfolio Risk Statistics area.
  - Updated configuration criteria to display unresolved alerts more clearly without altering the visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->