### PR TITLE
Parent vs child workflows get by id hotfix

### DIFF
--- a/services/workflows-service/src/workflow/types/index.ts
+++ b/services/workflows-service/src/workflow/types/index.ts
@@ -24,6 +24,7 @@ export type CompleteWorkflowData = WorkflowRuntimeData & {
 export type TEntityType = 'endUser' | 'business';
 
 export type TWorkflowWithRelations = WorkflowRuntimeData & {
+  workflowType: 'parent' | 'child';
   workflowDefinition: WorkflowDefinition;
   assignee: User;
   parentRuntimeId?: string;

--- a/services/workflows-service/src/workflow/workflow-runtime-data.repository.ts
+++ b/services/workflows-service/src/workflow/workflow-runtime-data.repository.ts
@@ -95,7 +95,7 @@ export class WorkflowRuntimeDataRepository {
   async findByIdWithRelations(id: string, projectIds: TProjectIds) {
     assertIsValidProjectIds(projectIds);
 
-    const [parentWorkflow, ...childWorkflows] = (await this.prismaService.$queryRaw`
+    const workflows = (await this.prismaService.$queryRaw`
         WITH workflows AS (
           SELECT
             CASE
@@ -291,6 +291,9 @@ export class WorkflowRuntimeDataRepository {
               individuals
           ) AS indie ON TRUE
   `) as TWorkflowWithRelations[];
+
+    const parentWorkflow = workflows.find(workflow => workflow.workflowType === 'parent');
+    const childWorkflows = workflows.filter(workflow => workflow.workflowType === 'child');
 
     if (!parentWorkflow) {
       throw new NotFoundException(`A workflow with an id of "${id}" was not found`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workflows are now explicitly categorized as either "parent" or "child," improving clarity when viewing workflow relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->