### PR TITLE
KYC options disabled state and readonly checkboxes

### DIFF
--- a/apps/backoffice-v2/src/common/components/atoms/ReadOnlyDetail/ReadOnlyDetail.tsx
+++ b/apps/backoffice-v2/src/common/components/atoms/ReadOnlyDetail/ReadOnlyDetail.tsx
@@ -59,7 +59,12 @@ export const ReadOnlyDetail: FunctionComponent<{
 
   if (parse?.boolean && typeof children === 'boolean') {
     return (
-      <Checkbox_ {...props} checked={children} className={ctw('border-[#E5E7EB]', className)} />
+      <Checkbox_
+        {...props}
+        checked={children}
+        className={ctw('border-[#E5E7EB]', className)}
+        disabled
+      />
     );
   }
 

--- a/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/utils/useTabsToBlocksMap.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/utils/useTabsToBlocksMap.tsx
@@ -180,10 +180,12 @@ export const useTabsToBlocksMap = ({
         )?.enum as string[],
       isReuploadNeededDisabled: isLoadingRevisionCase,
       isApproveDisabled: isLoadingApproveCase,
-      isInitiateKycDisabled: !initiateKycEvent,
-      isInitiateSanctionsScreeningDisabled:
-        !initiateSanctionsScreeningEvent ||
+      isInitiateKycDisabled: !initiateKycEvent || !caseState.actionButtonsEnabled,
+      isInitiateSanctionsScreeningDisabled: [
+        !initiateSanctionsScreeningEvent,
         !workflow?.workflowDefinition?.config?.isInitiateSanctionsScreeningEnabled,
+        !caseState.actionButtonsEnabled,
+      ].some(Boolean),
     } satisfies Parameters<typeof createKycBlocks>[0][number];
   };
   const directorToIndividualAdapter = ({


### PR DESCRIPTION
- feat(backoffice-v2): now disabling kyc block options when unassigned
- fix(backoffice-v2): readonly checkboxes now are styled like readonly and are disabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Checkboxes displayed as read-only now appear disabled, preventing user interaction.
	- Improved accuracy of disabling logic for "Initiate KYC" and "Initiate Sanctions Screening" buttons, ensuring they are only enabled when all relevant conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->