### PR TITLE
BAL-3347: Empty state for individuals tab

### DIFF
--- a/apps/backoffice-v2/src/common/components/atoms/icons/index.tsx
+++ b/apps/backoffice-v2/src/common/components/atoms/icons/index.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, FunctionComponent, SVGProps } from 'react';
+import { ComponentProps, FunctionComponent, SVGProps } from 'react';
 import { ctw } from '../../../utils/ctw/ctw';
 
 /**
@@ -675,3 +675,69 @@ export const DownloadFileSvg: FunctionComponent<ComponentProps<'svg'>> = props =
     />
   </svg>
 );
+
+export const NoIndividualsSvg: FunctionComponent<ComponentProps<'svg'>> = props => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="80" height="79" viewBox="0 0 80 79" fill="none">
+      <circle cx="39" cy="40" r="39" fill="#D9D9D9" />
+      <path
+        d="M9 24H68C69.6569 24 71 25.3431 71 27V72C71 73.6569 69.6569 75 68 75H9C7.34315 75 6 73.6569 6 72V27C6 25.3431 7.34315 24 9 24Z"
+        fill="#D9D9D9"
+        stroke="black"
+        strokeWidth="2"
+      />
+      <path
+        d="M68 39V33.6667C68 31.8986 67.2475 30.2029 65.9079 28.9526C64.5684 27.7024 62.7515 27 60.8571 27H50.1429C48.2485 27 46.4316 27.7024 45.0921 28.9526C43.7525 30.2029 43 31.8986 43 33.6667V39"
+        fill="white"
+        fillOpacity="0.3"
+      />
+      <path
+        d="M68 39V33.6667C68 31.8986 67.2475 30.2029 65.9079 28.9526C64.5684 27.7024 62.7515 27 60.8571 27H50.1429C48.2485 27 46.4316 27.7024 45.0921 28.9526C43.7525 30.2029 43 31.8986 43 33.6667V39"
+        stroke="#9B9B9B"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeDasharray="4 4"
+      />
+      <path
+        d="M48 30V26.6667C48 24.8986 47.2475 23.2029 45.9079 21.9526C44.5684 20.7024 42.7515 20 40.8571 20H30.1429C28.2485 20 26.4316 20.7024 25.0921 21.9526C23.7525 23.2029 23 24.8986 23 26.6667V30"
+        fill="white"
+        fillOpacity="0.6"
+      />
+      <path
+        d="M48 30V26.6667C48 24.8986 47.2475 23.2029 45.9079 21.9526C44.5684 20.7024 42.7515 20 40.8571 20H30.1429C28.2485 20 26.4316 20.7024 25.0921 21.9526C23.7525 23.2029 23 24.8986 23 26.6667V30"
+        stroke="#9B9B9B"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeDasharray="4 4"
+      />
+      <path
+        d="M55.5 23C59.6421 23 63 19.6421 63 15.5C63 11.3579 59.6421 8 55.5 8C51.3579 8 48 11.3579 48 15.5C48 19.6421 51.3579 23 55.5 23Z"
+        fill="white"
+        fillOpacity="0.3"
+        stroke="#9B9B9B"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeDasharray="3 4"
+      />
+      <path
+        d="M35.5 16C39.6421 16 43 12.6421 43 8.5C43 4.35786 39.6421 1 35.5 1C31.3579 1 28 4.35786 28 8.5C28 12.6421 31.3579 16 35.5 16Z"
+        fill="white"
+        fillOpacity="0.6"
+        stroke="#9B9B9B"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeDasharray="3 4"
+      />
+      <path
+        d="M17.9248 29H46.6367C47.2097 29.0001 47.7687 29.1645 48.249 29.4707L48.4502 29.6104L52.4463 32.6426C53.3158 33.3025 54.3772 33.6601 55.4688 33.6602H75.1572C76.9824 33.6602 78.3704 35.2709 78.1318 37.0537L78.1035 37.2266L71.3086 72.5664C71.037 73.979 69.8007 75 68.3623 75H9.88379C8.04866 74.9998 6.6585 73.3723 6.91309 71.582L6.94336 71.4092L14.9834 31.4092C15.265 30.0083 16.496 29.0001 17.9248 29Z"
+        fill="white"
+        stroke="black"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+};

--- a/apps/backoffice-v2/src/lib/blocks/components/NoDataCell/NoDataCell.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/components/NoDataCell/NoDataCell.tsx
@@ -1,28 +1,20 @@
 import { Card } from '@/common/components/atoms/Card/Card';
 import { CardContent } from '@/common/components/atoms/Card/Card.Content';
 import { ctw } from '@/common/utils/ctw/ctw';
+import { ExtractCellProps } from '@ballerine/blocks';
 import { FunctionComponent } from 'react';
 
-interface INoDataCellProps {
-  type: 'noData';
-  props: {
-    title: string;
-    description: string;
-    icon: JSX.Element;
-    className?: string;
-  };
-}
-
-export const NoDataCell: FunctionComponent<INoDataCellProps> = ({ props }) => {
-  const { title, description, icon, className } = props;
+export const NoDataCell: FunctionComponent<ExtractCellProps<'noData'>> = ({ value, props }) => {
+  const { className } = props;
+  const { title, description, icon } = value;
 
   return (
     <Card className={ctw('shadow-[0_4px_4px_0_rgba(174,174,174,0.0625)]', className)}>
       <CardContent className="flex flex-col gap-4 p-6">
         <div className="flex justify-center">{icon}</div>
         <div className="flex flex-col gap-2">
-          <p className="text-lg font-semibold">{title}</p>
-          <p className="text-sm leading-[28px]">{description}</p>
+          <h3 className="text-lg font-semibold">{title}</h3>
+          <h4 className="text-sm leading-[28px]">{description}</h4>
         </div>
       </CardContent>
     </Card>

--- a/apps/backoffice-v2/src/lib/blocks/components/NoDataCell/NoDataCell.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/components/NoDataCell/NoDataCell.tsx
@@ -1,0 +1,30 @@
+import { Card } from '@/common/components/atoms/Card/Card';
+import { CardContent } from '@/common/components/atoms/Card/Card.Content';
+import { ctw } from '@/common/utils/ctw/ctw';
+import { FunctionComponent } from 'react';
+
+interface INoDataCellProps {
+  type: 'noData';
+  props: {
+    title: string;
+    description: string;
+    icon: JSX.Element;
+    className?: string;
+  };
+}
+
+export const NoDataCell: FunctionComponent<INoDataCellProps> = ({ props }) => {
+  const { title, description, icon, className } = props;
+
+  return (
+    <Card className={ctw('shadow-[0_4px_4px_0_rgba(174,174,174,0.0625)]', className)}>
+      <CardContent className="flex flex-col gap-4 p-6">
+        <div className="flex justify-center">{icon}</div>
+        <div className="flex flex-col gap-2">
+          <p className="text-lg font-semibold">{title}</p>
+          <p className="text-sm leading-[28px]">{description}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/backoffice-v2/src/lib/blocks/create-blocks-typed/create-blocks-typed.ts
+++ b/apps/backoffice-v2/src/lib/blocks/create-blocks-typed/create-blocks-typed.ts
@@ -22,6 +22,7 @@ import { TableCell } from '@/lib/blocks/components/TableCell/TableCell';
 import { TCell } from '@/lib/blocks/create-blocks-typed/types';
 import { CellsMap, createBlocks } from '@ballerine/blocks';
 import { EditableDetailsV2Cell } from '../components/EditableDetailsV2Cell/EditableDetailsV2Cell';
+import { NoDataCell } from '../components/NoDataCell/NoDataCell';
 
 export const createBlocksTyped = () => createBlocks<TCell>();
 
@@ -56,4 +57,5 @@ export const cells: CellsMap = {
   readOnlyDetails: ReadOnlyDetailsCell,
   image: ImageCell,
   editableDetails: EditableDetailsV2Cell,
+  noData: NoDataCell,
 };

--- a/apps/backoffice-v2/src/lib/blocks/create-blocks-typed/types.ts
+++ b/apps/backoffice-v2/src/lib/blocks/create-blocks-typed/types.ts
@@ -25,7 +25,6 @@ import { ComponentProps, ReactNode } from 'react';
 import { ReadOnlyDetail } from '@/common/components/atoms/ReadOnlyDetail/ReadOnlyDetail';
 import { EditableDetailsV2 } from '@/common/components/organisms/EditableDetailsV2/EditableDetailsV2';
 import { DataTable } from '@ballerine/ui/dist/components/organisms/DataTable/DataTable';
-import { NoDataCell } from '../components/NoDataCell/NoDataCell';
 
 export type TBlockCell = {
   type: 'block';
@@ -261,7 +260,14 @@ export type TEditableDetailsV2Cell = {
 
 export type TNoDataCell = {
   type: 'noData';
-  props: Omit<ComponentProps<typeof NoDataCell>, 'type'>;
+  value: {
+    title: string;
+    description: string;
+    icon: JSX.Element;
+  };
+  props: {
+    className?: string;
+  };
 };
 
 export type TCell =

--- a/apps/backoffice-v2/src/lib/blocks/create-blocks-typed/types.ts
+++ b/apps/backoffice-v2/src/lib/blocks/create-blocks-typed/types.ts
@@ -25,6 +25,7 @@ import { ComponentProps, ReactNode } from 'react';
 import { ReadOnlyDetail } from '@/common/components/atoms/ReadOnlyDetail/ReadOnlyDetail';
 import { EditableDetailsV2 } from '@/common/components/organisms/EditableDetailsV2/EditableDetailsV2';
 import { DataTable } from '@ballerine/ui/dist/components/organisms/DataTable/DataTable';
+import { NoDataCell } from '../components/NoDataCell/NoDataCell';
 
 export type TBlockCell = {
   type: 'block';
@@ -258,6 +259,11 @@ export type TEditableDetailsV2Cell = {
   props: Omit<ComponentProps<typeof EditableDetailsV2>, 'fields'>;
 };
 
+export type TNoDataCell = {
+  type: 'noData';
+  props: Omit<ComponentProps<typeof NoDataCell>, 'type'>;
+};
+
 export type TCell =
   | TBlockCell
   | TContainerCell
@@ -281,4 +287,5 @@ export type TCell =
   | TPDFViewerCell
   | TReadOnlyDetailsCell
   | TImageCell
-  | TEditableDetailsV2Cell;
+  | TEditableDetailsV2Cell
+  | TNoDataCell;

--- a/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/hooks/useKYCBlocks/useKYCBlocks.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/hooks/useKYCBlocks/useKYCBlocks.tsx
@@ -1,0 +1,27 @@
+import { KycBlock } from '@/lib/blocks/components/KycBlock/KycBlock';
+import { ComponentProps, useMemo } from 'react';
+import { createKycBlocks } from '../../utils/create-kyc-blocks';
+import { createBlocksTyped } from '@/lib/blocks/create-blocks-typed/create-blocks-typed';
+import { NoIndividualsSvg } from '@/common/components/atoms/icons';
+
+export const useKYCBlocks = (individuals: Array<ComponentProps<typeof KycBlock>>) => {
+  const kycBlocks = useMemo(() => {
+    if (individuals?.length) {
+      return createKycBlocks(individuals);
+    }
+
+    return createBlocksTyped()
+      .addBlock()
+      .addCell({
+        type: 'noData',
+        props: {
+          title: 'No Individuals Data Available',
+          description: `Individual's information is still being collected or not available.`,
+          icon: <NoIndividualsSvg />,
+        },
+      })
+      .build();
+  }, [individuals]);
+
+  return kycBlocks;
+};

--- a/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/hooks/useKYCBlocks/useKYCBlocks.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/hooks/useKYCBlocks/useKYCBlocks.tsx
@@ -14,11 +14,12 @@ export const useKYCBlocks = (individuals: Array<ComponentProps<typeof KycBlock>>
       .addBlock()
       .addCell({
         type: 'noData',
-        props: {
+        value: {
           title: 'No Individuals Data Available',
           description: `Individual's information is still being collected or not available.`,
           icon: <NoIndividualsSvg />,
         },
+        props: {},
       })
       .build();
   }, [individuals]);

--- a/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/utils/get-variant-tabs.ts
+++ b/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/utils/get-variant-tabs.ts
@@ -35,7 +35,7 @@ export const getVariantTabs = (
       {
         name: Tab.INDIVIDUALS,
         displayName: 'Individuals',
-        disabled: !tabBlocks[Tab.INDIVIDUALS]?.length,
+        disabled: false,
       },
       {
         name: Tab.DOCUMENTS,

--- a/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/utils/useTabsToBlocksMap.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/variants/DefaultBlocks/hooks/useCaseBlocksLogic/utils/useTabsToBlocksMap.tsx
@@ -12,7 +12,8 @@ import { useApproveCaseAndDocumentsMutation } from '@/domains/entities/hooks/mut
 import { useEventMutation } from '@/domains/workflows/hooks/mutations/useEventMutation/useEventMutation';
 import { useCurrentCaseQuery } from '@/pages/Entity/hooks/useCurrentCaseQuery/useCurrentCaseQuery';
 import { TAllBlocks } from '../../useDefaultBlocksLogic/constants';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useKYCBlocks } from '../hooks/useKYCBlocks/useKYCBlocks';
 
 export type TCaseBlocksCreationProps = {
   workflow: TWorkflowById;
@@ -115,114 +116,132 @@ export const useTabsToBlocksMap = ({
       return 'pending';
     }
   };
-  const childWorkflowToIndividualAdapter = (
-    childWorkflow: NonNullable<TWorkflowById['childWorkflows']>[number],
-  ) => {
-    const status = getStatus(childWorkflow?.tags ?? []);
-    const initiateKycEvent = getInitiateKycEvent(childWorkflow?.nextEvents ?? []);
-    const initiateSanctionsScreeningEvent = getInitiateSanctionsScreeningEvent(
-      childWorkflow?.nextEvents ?? [],
-    );
-    const endUser = endUsers?.find(
-      endUser => endUser.id === childWorkflow?.context?.entity?.data?.ballerineEntityId,
-    );
+  const childWorkflowToIndividualAdapter = useCallback(
+    (childWorkflow: NonNullable<TWorkflowById['childWorkflows']>[number]) => {
+      const status = getStatus(childWorkflow?.tags ?? []);
+      const initiateKycEvent = getInitiateKycEvent(childWorkflow?.nextEvents ?? []);
+      const initiateSanctionsScreeningEvent = getInitiateSanctionsScreeningEvent(
+        childWorkflow?.nextEvents ?? [],
+      );
+      const endUser = endUsers?.find(
+        endUser => endUser.id === childWorkflow?.context?.entity?.data?.ballerineEntityId,
+      );
 
-    return {
-      status,
-      documents: childWorkflow?.context?.documents,
-      kycSession: omitPropsFromObject(
-        childWorkflow?.context?.pluginsOutput?.kyc_session ?? {},
-        'invokedAt',
-      ),
-      aml: {
-        hits: endUser?.amlHits,
-      },
-      entityData: childWorkflow?.context?.entity?.data,
-      isActionsDisabled:
-        !caseState.actionButtonsEnabled || !childWorkflow?.tags?.includes(StateTag.MANUAL_REVIEW),
-      isLoadingReuploadNeeded: isLoadingRevisionCase,
-      isLoadingApprove: isLoadingApproveCase,
-      onInitiateKyc: () => {
-        if (!initiateKycEvent) {
-          return;
-        }
+      return {
+        status,
+        documents: childWorkflow?.context?.documents,
+        kycSession: omitPropsFromObject(
+          childWorkflow?.context?.pluginsOutput?.kyc_session ?? {},
+          'invokedAt',
+        ),
+        aml: {
+          hits: endUser?.amlHits,
+        },
+        entityData: childWorkflow?.context?.entity?.data,
+        isActionsDisabled:
+          !caseState.actionButtonsEnabled || !childWorkflow?.tags?.includes(StateTag.MANUAL_REVIEW),
+        isLoadingReuploadNeeded: isLoadingRevisionCase,
+        isLoadingApprove: isLoadingApproveCase,
+        onInitiateKyc: () => {
+          if (!initiateKycEvent) {
+            return;
+          }
 
-        mutateEvent({
-          workflowId: childWorkflow?.id,
-          event: initiateKycEvent,
-        });
-      },
-      onInitiateSanctionsScreening: () => {
-        if (!initiateSanctionsScreeningEvent) {
-          return;
-        }
-
-        mutateEvent({
-          workflowId: childWorkflow?.id,
-          event: initiateSanctionsScreeningEvent,
-        });
-      },
-      onApprove:
-        ({ ids }: { ids: string[] }) =>
-        () =>
-          mutateApproveCase({ ids, workflowId: childWorkflow?.id }),
-      onReuploadNeeded:
-        ({ reason, ids }: { reason: string; ids: string[] }) =>
-        () =>
-          mutateRevisionCase({
-            revisionReason: reason,
-            ids,
+          mutateEvent({
             workflowId: childWorkflow?.id,
-          }),
-      reasons:
-        childWorkflow?.workflowDefinition?.contextSchema?.schema?.properties?.documents?.items?.properties?.decision?.properties?.revisionReason?.anyOf?.find(
-          ({ enum: enum_ }) => !!enum_,
-        )?.enum as string[],
-      isReuploadNeededDisabled: isLoadingRevisionCase,
-      isApproveDisabled: isLoadingApproveCase,
-      isInitiateKycDisabled: !initiateKycEvent || !caseState.actionButtonsEnabled,
-      isInitiateSanctionsScreeningDisabled: [
-        !initiateSanctionsScreeningEvent,
-        !workflow?.workflowDefinition?.config?.isInitiateSanctionsScreeningEnabled,
-        !caseState.actionButtonsEnabled,
-      ].some(Boolean),
-    } satisfies Parameters<typeof createKycBlocks>[0][number];
-  };
-  const directorToIndividualAdapter = ({
-    kycSession,
-    aml,
-    ...director
-  }: NonNullable<
-    TWorkflowById['context']['entity']['data']['additionalInfo']['directors']
-  >[number]) => {
-    return {
-      status: undefined,
-      documents: director?.documents,
+            event: initiateKycEvent,
+          });
+        },
+        onInitiateSanctionsScreening: () => {
+          if (!initiateSanctionsScreeningEvent) {
+            return;
+          }
+
+          mutateEvent({
+            workflowId: childWorkflow?.id,
+            event: initiateSanctionsScreeningEvent,
+          });
+        },
+        onApprove:
+          ({ ids }: { ids: string[] }) =>
+          () =>
+            mutateApproveCase({ ids, workflowId: childWorkflow?.id }),
+        onReuploadNeeded:
+          ({ reason, ids }: { reason: string; ids: string[] }) =>
+          () =>
+            mutateRevisionCase({
+              revisionReason: reason,
+              ids,
+              workflowId: childWorkflow?.id,
+            }),
+        reasons:
+          childWorkflow?.workflowDefinition?.contextSchema?.schema?.properties?.documents?.items?.properties?.decision?.properties?.revisionReason?.anyOf?.find(
+            ({ enum: enum_ }) => !!enum_,
+          )?.enum as string[],
+        isReuploadNeededDisabled: isLoadingRevisionCase,
+        isApproveDisabled: isLoadingApproveCase,
+        isInitiateKycDisabled: !initiateKycEvent || !caseState.actionButtonsEnabled,
+        isInitiateSanctionsScreeningDisabled: [
+          !initiateSanctionsScreeningEvent,
+          !workflow?.workflowDefinition?.config?.isInitiateSanctionsScreeningEnabled,
+          !caseState.actionButtonsEnabled,
+        ].some(Boolean),
+      } satisfies Parameters<typeof createKycBlocks>[0][number];
+    },
+    [
+      caseState.actionButtonsEnabled,
+      endUsers,
+      isLoadingApproveCase,
+      isLoadingRevisionCase,
+      mutateApproveCase,
+      mutateEvent,
+      mutateRevisionCase,
+      workflow?.workflowDefinition?.config?.isInitiateSanctionsScreeningEnabled,
+    ],
+  );
+
+  const directorToIndividualAdapter = useCallback(
+    ({
       kycSession,
       aml,
-      entityData: director,
-      isActionsDisabled: true,
-      isLoadingReuploadNeeded: false,
-      isLoadingApprove: false,
-      onInitiateKyc: () => {},
-      onInitiateSanctionsScreening: () => {},
-      onApprove:
-        ({ ids }: { ids: string[] }) =>
-        () => {},
-      onReuploadNeeded:
-        ({ reason, ids }: { reason: string; ids: string[] }) =>
-        () => {},
-      reasons: [],
-      isReuploadNeededDisabled: true,
-      isApproveDisabled: true,
-      isInitiateKycDisabled: true,
-      isInitiateSanctionsScreeningDisabled: true,
-    } satisfies Parameters<typeof createKycBlocks>[0][number];
-  };
-  const childWorkflows =
-    workflow?.childWorkflows
-      ?.filter(childWorkflow => childWorkflow?.context?.entity?.type === 'individual')
-      ?.map(childWorkflowToIndividualAdapter) ?? [];
+      ...director
+    }: NonNullable<
+      TWorkflowById['context']['entity']['data']['additionalInfo']['directors']
+    >[number]) => {
+      return {
+        status: undefined,
+        documents: director?.documents,
+        kycSession,
+        aml,
+        entityData: director,
+        isActionsDisabled: true,
+        isLoadingReuploadNeeded: false,
+        isLoadingApprove: false,
+        onInitiateKyc: () => {},
+        onInitiateSanctionsScreening: () => {},
+        onApprove:
+          ({ ids }: { ids: string[] }) =>
+          () => {},
+        onReuploadNeeded:
+          ({ reason, ids }: { reason: string; ids: string[] }) =>
+          () => {},
+        reasons: [],
+        isReuploadNeededDisabled: true,
+        isApproveDisabled: true,
+        isInitiateKycDisabled: true,
+        isInitiateSanctionsScreeningDisabled: true,
+      } satisfies Parameters<typeof createKycBlocks>[0][number];
+    },
+    [],
+  );
+
+  const childWorkflows = useMemo(
+    () =>
+      workflow?.childWorkflows
+        ?.filter(childWorkflow => childWorkflow?.context?.entity?.type === 'individual')
+        ?.map(childWorkflowToIndividualAdapter) ?? [],
+    [workflow?.childWorkflows, childWorkflowToIndividualAdapter],
+  );
 
   const deDupedDirectors = useMemo(
     () =>
@@ -248,10 +267,15 @@ export const useTabsToBlocksMap = ({
             },
           });
         }) ?? [],
-    [workflow?.context?.entity?.data?.additionalInfo?.directors, endUsers],
+    [endUsers, directorToIndividualAdapter, workflow],
   );
 
-  const individuals = [...childWorkflows, ...deDupedDirectors];
+  const individuals = useMemo(
+    () => [...childWorkflows, ...deDupedDirectors],
+    [childWorkflows, deDupedDirectors],
+  );
+
+  const kycBlocks = useKYCBlocks(individuals);
 
   const defaultTabsMap = {
     [Tab.SUMMARY]: [
@@ -290,7 +314,7 @@ export const useTabsToBlocksMap = ({
       ...mainRepresentativeBlock,
       ...uboDocumentBlocks,
       ...directorDocumentBlocks,
-      ...createKycBlocks(individuals),
+      ...kycBlocks,
     ],
     [Tab.ASSOCIATED_COMPANIES]: [
       ...associatedCompaniesBlock,
@@ -313,11 +337,7 @@ export const useTabsToBlocksMap = ({
 
   if (theme?.type === WorkflowDefinitionConfigThemeEnum.KYC) {
     return {
-      [Tab.KYC]: [
-        ...businessInformationBlocks,
-        ...amlWithContainerBlock,
-        ...createKycBlocks(individuals),
-      ],
+      [Tab.KYC]: [...businessInformationBlocks, ...amlWithContainerBlock, ...kycBlocks],
     } as const;
   }
 


### PR DESCRIPTION
- Added new icon
- Added `noData` block
- added empty state for using noData block for individuals in individuals tab

![image](https://github.com/user-attachments/assets/8d44dd29-df86-4d94-8784-d45b887933aa)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "No Data" cell component to display a message and icon when individual data is unavailable.
  - Added a new icon representing multiple individuals for use in empty states.
  - The "Individuals" tab now remains enabled even when no data is present, showing the new "No Data" cell as feedback.
  - Added a hook to efficiently generate KYC blocks based on available individual data.

- **Refactor**
  - Improved performance and maintainability of tab and block mapping logic through enhanced memoization and use of hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->