### PR TITLE
fix: adjust ecosystem table column headings

### DIFF
--- a/packages/ui/src/components/templates/report/components/Ecosystem/components/EcosystemTable/columns.tsx
+++ b/packages/ui/src/components/templates/report/components/Ecosystem/components/EcosystemTable/columns.tsx
@@ -13,15 +13,15 @@ const columnHelper = createColumnHelper<{
 export const columns = [
   columnHelper.display({
     id: 'index',
+    header: 'Number',
     cell: info => {
       const index = info.cell.row.index + 1;
 
       return <TextWithNAFallback className={`ps-8`}>{index}</TextWithNAFallback>;
     },
-    header: 'Match',
   }),
   columnHelper.accessor('domain', {
-    header: 'Matched Name',
+    header: 'Domain',
     cell: info => {
       const domain = info.getValue();
       const addProtocolIfMissing = (url: string) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated column header labels in the ecosystem table: "Match" is now "Number" and "Matched Name" is now "Domain".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->