### PR TITLE
feat: completed screen now can be disabled during redirect in theme

### DIFF
--- a/.changeset/eleven-zebras-guess.md
+++ b/.changeset/eleven-zebras-guess.md
@@ -1,0 +1,5 @@
+---
+'@ballerine/kyb-app': patch
+---
+
+Bump

--- a/apps/kyb-app/src/common/types/settings.ts
+++ b/apps/kyb-app/src/common/types/settings.ts
@@ -33,6 +33,9 @@ export interface ITheme {
     };
   };
   settings: Partial<ISettings>;
+  completedPage?: {
+    disableDuringRedirect?: boolean;
+  };
 }
 
 export interface ISettings {

--- a/apps/kyb-app/src/pages/CollectionFlow/versions/v1/components/pages/CompletedScreen/CompletedScreen.tsx
+++ b/apps/kyb-app/src/pages/CollectionFlow/versions/v1/components/pages/CompletedScreen/CompletedScreen.tsx
@@ -6,6 +6,7 @@ import { useAppExit } from '@/hooks/useAppExit/useAppExit';
 import { Button, Card } from '@ballerine/ui';
 import { FunctionComponent, useEffect } from 'react';
 import { Loader2 } from 'lucide-react';
+import { useTheme } from '@/common/providers/ThemeProvider';
 
 interface ICompletedScreenProps {
   redirectUrl?: string;
@@ -14,7 +15,8 @@ interface ICompletedScreenProps {
 export const CompletedScreen: FunctionComponent<ICompletedScreenProps> = ({ redirectUrl }) => {
   const { t } = useTranslation();
   const { customer } = useCustomer();
-
+  const { themeDefinition } = useTheme();
+  const { disableDuringRedirect = false } = themeDefinition?.completedPage || {};
   const { exit, isExitAvailable } = useAppExit();
 
   useEffect(() => {
@@ -22,6 +24,10 @@ export const CompletedScreen: FunctionComponent<ICompletedScreenProps> = ({ redi
       window.location.href = redirectUrl;
     }
   }, [redirectUrl]);
+
+  if (redirectUrl && disableDuringRedirect) {
+    return null;
+  }
 
   return (
     <div className="flex h-full items-center justify-center">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new theme option to control UI display during redirect on the completed page. When enabled, the completed screen will not render if a redirect is in progress.

- **Chores**
  - Updated internal dependencies and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->