### PR TITLE
Fix replaceNullsWithUndefined array handling

### DIFF
--- a/packages/common/src/utils/replace-null-with-undefined/replace-null-with-undefined.ts
+++ b/packages/common/src/utils/replace-null-with-undefined/replace-null-with-undefined.ts
@@ -3,7 +3,11 @@ export const replaceNullsWithUndefined = (obj: unknown) => {
     return undefined;
   }
 
-  if (typeof obj !== 'object' || Array.isArray(obj)) {
+  if (Array.isArray(obj)) {
+    return obj.map(item => replaceNullsWithUndefined(item));
+  }
+
+  if (typeof obj !== 'object') {
     return obj;
   }
 

--- a/packages/common/src/utils/replace-null-with-undefined/replace-null-with-undefined.unit.test.ts
+++ b/packages/common/src/utils/replace-null-with-undefined/replace-null-with-undefined.unit.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { replaceNullsWithUndefined } from './replace-null-with-undefined';
+
+describe('replaceNullsWithUndefined', () => {
+  it('replaces nulls in objects recursively', () => {
+    const input = { a: null, b: { c: null, d: 1 } };
+    expect(replaceNullsWithUndefined(input)).toEqual({ a: undefined, b: { c: undefined, d: 1 } });
+  });
+
+  it('replaces nulls inside arrays', () => {
+    const input = { arr: [null, { x: null }, 1] };
+    expect(replaceNullsWithUndefined(input)).toEqual({ arr: [undefined, { x: undefined }, 1] });
+  });
+});


### PR DESCRIPTION
## Summary
- handle arrays recursively in `replaceNullsWithUndefined`
- add unit tests for the new behavior

## Testing
- `pnpm exec vitest run -c packages/common/vitest.config.ts` *(fails: Command "vitest" not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of arrays to ensure all nested null values are consistently replaced with undefined, including within arrays and nested structures.

- **Tests**
  - Added comprehensive tests to verify correct replacement of null values with undefined in both objects and arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->