### PR TITLE
feat: added rendering of original registry info values(wip, may be canceled)

### DIFF
--- a/apps/backoffice-v2/src/common/components/molecules/RegistryOriginValueTitle/RegistryOriginValueTitle.tsx
+++ b/apps/backoffice-v2/src/common/components/molecules/RegistryOriginValueTitle/RegistryOriginValueTitle.tsx
@@ -1,0 +1,37 @@
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@ballerine/ui';
+import { InfoIcon } from 'lucide-react';
+
+import { FunctionComponent } from 'react';
+import { toTitleCase } from 'string-ts';
+
+interface IRegistryOriginValueTitle {
+  title: string;
+  originalValue: string;
+}
+
+export const RegistryOriginValueTitle: FunctionComponent<IRegistryOriginValueTitle> = ({
+  title,
+  originalValue,
+}) => {
+  return (
+    <div className="group relative flex items-center gap-2 rounded-md">
+      <HoverCard openDelay={0} open={originalValue ? undefined : false}>
+        <HoverCardTrigger asChild>
+          <div className="flex cursor-help items-center gap-2">
+            <span className="font-medium text-gray-700">{toTitleCase(title)}</span>
+            {originalValue && <InfoIcon className="h-4 w-4 text-gray-500" />}
+          </div>
+        </HoverCardTrigger>
+        <HoverCardContent side="top" align="center" className="w-80">
+          <div className="space-y-2">
+            <p className="text-sm text-gray-600">
+              The value in parentheses is the original value from the registry, while the value
+              below is normalized for consistency
+            </p>
+            <p className="text-sm font-medium text-gray-500">Original value: {originalValue}</p>
+          </div>
+        </HoverCardContent>
+      </HoverCard>
+    </div>
+  );
+};

--- a/apps/backoffice-v2/src/lib/blocks/components/EditableDetails/EditableDetails.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/components/EditableDetails/EditableDetails.tsx
@@ -299,7 +299,6 @@ export const EditableDetails: FunctionComponent<IEditableDetails> = ({
               dropdownOptions,
               titleNode,
             }) => {
-              console.log('title node', titleNode);
               const originalValue = form.watch(title);
 
               const displayValue = (value: unknown) => {

--- a/apps/backoffice-v2/src/lib/blocks/components/EditableDetails/EditableDetails.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/components/EditableDetails/EditableDetails.tsx
@@ -264,7 +264,11 @@ export const EditableDetails: FunctionComponent<IEditableDetails> = ({
     [],
   );
 
-  useWatchDropdownOptions({ form, data, setFormData });
+  useWatchDropdownOptions({
+    form,
+    data: data,
+    setFormData,
+  });
   useInitialCategorySetValue({
     form,
     data,
@@ -293,7 +297,9 @@ export const EditableDetails: FunctionComponent<IEditableDetails> = ({
               value,
               valueAlias,
               dropdownOptions,
+              titleNode,
             }) => {
+              console.log('title node', titleNode);
               const originalValue = form.watch(title);
 
               const displayValue = (value: unknown) => {
@@ -335,7 +341,7 @@ export const EditableDetails: FunctionComponent<IEditableDetails> = ({
 
                     return (
                       <FormItem>
-                        <FormLabel>{toTitleCase(title)}</FormLabel>
+                        <FormLabel>{titleNode ?? toTitleCase(title)}</FormLabel>
                         {(isObject(value) || Array.isArray(value)) && (
                           <div
                             className={`flex items-end justify-start`}

--- a/apps/backoffice-v2/src/lib/blocks/components/EditableDetails/hooks/useWatchDropdown.ts
+++ b/apps/backoffice-v2/src/lib/blocks/components/EditableDetails/hooks/useWatchDropdown.ts
@@ -7,7 +7,11 @@ export const useWatchDropdownOptions = ({ form, data, setFormData }) => {
   useEffect(() => {
     const subscription = watch((value, { name }) => {
       if (!['category'].includes(name)) return subscription.unsubscribe();
-      const newData = structuredClone(data);
+      const newData = data.map(({ titleNode, ...rest }) => {
+        const restCopy = structuredClone(rest);
+        restCopy.titleNode = titleNode;
+        return restCopy;
+      });
 
       newData
         .filter(item => !!item.dropdownOptions)

--- a/apps/backoffice-v2/src/lib/blocks/components/EditableDetails/interfaces.ts
+++ b/apps/backoffice-v2/src/lib/blocks/components/EditableDetails/interfaces.ts
@@ -1,5 +1,6 @@
 import { AnyObject } from '@ballerine/ui';
 import { TDropdownOption } from './types';
+import { ReactNode } from 'react';
 
 export type IEditableDetailsDocument = {
   propertiesSchema: Record<string, unknown>;
@@ -10,6 +11,7 @@ export type IEditableDetailsDocument = {
 export interface IEditableDetails {
   data: Array<{
     title: string;
+    titleNode?: ReactNode;
     value: unknown;
     valueAlias?: unknown;
     isEditable: boolean;

--- a/apps/backoffice-v2/src/lib/blocks/hooks/useKybRegistryInfoBlock/useKybRegistryInfoBlock.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/hooks/useKybRegistryInfoBlock/useKybRegistryInfoBlock.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { createBlocksTyped } from '@/lib/blocks/create-blocks-typed/create-blocks-typed';
 import { WarningFilledSvg } from '@ballerine/ui';
 import { systemCreatedIconCell } from '@/lib/blocks/utils/constants';
+import { RegistryOriginValueTitle } from '@/common/components/molecules/RegistryOriginValueTitle/RegistryOriginValueTitle';
 
 export const useKybRegistryInfoBlock = ({ pluginsOutput, workflow }) => {
   const getCell = useCallback(() => {
@@ -14,6 +15,14 @@ export const useKybRegistryInfoBlock = ({ pluginsOutput, workflow }) => {
         value: {
           data: Object.entries(pluginsOutput?.businessInformation?.data?.[0])?.map(
             ([title, value]) => ({
+              titleNode: pluginsOutput?.businessInformation?.data?.[0]?._raw?.[title]?.original ? (
+                <RegistryOriginValueTitle
+                  title={title}
+                  originalValue={
+                    pluginsOutput?.businessInformation?.data?.[0]?._raw?.[title]?.original
+                  }
+                />
+              ) : undefined,
               title,
               value,
             }),

--- a/apps/backoffice-v2/src/lib/blocks/hooks/useKybRegistryInfoBlock/useKybRegistryInfoBlock.tsx
+++ b/apps/backoffice-v2/src/lib/blocks/hooks/useKybRegistryInfoBlock/useKybRegistryInfoBlock.tsx
@@ -15,11 +15,12 @@ export const useKybRegistryInfoBlock = ({ pluginsOutput, workflow }) => {
         value: {
           data: Object.entries(pluginsOutput?.businessInformation?.data?.[0])?.map(
             ([title, value]) => ({
-              titleNode: pluginsOutput?.businessInformation?.data?.[0]?._raw?.[title]?.original ? (
+              titleNode: pluginsOutput?.businessInformation?.data?.[0]?.originalDates?.[title]
+                ?.original ? (
                 <RegistryOriginValueTitle
                   title={title}
                   originalValue={
-                    pluginsOutput?.businessInformation?.data?.[0]?._raw?.[title]?.original
+                    pluginsOutput?.businessInformation?.data?.[0]?.originalDates?.[title]?.original
                   }
                 />
               ) : undefined,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a visual indicator for original registry values in business information fields, allowing users to view both the normalized and original data via an info icon with hover details.

- **Enhancements**
  - Improved form field labels by supporting custom label nodes, providing clearer context for fields with original registry values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->