### PR TITLE
refactor(queue): remove logging from queue service's destroy method

### DIFF
--- a/services/workflows-service/src/common/queue/queue.service.ts
+++ b/services/workflows-service/src/common/queue/queue.service.ts
@@ -243,8 +243,6 @@ export class QueueService implements OnModuleDestroy {
   }
 
   async onModuleDestroy() {
-    this.logger.log('Closing all queues and workers');
-
     const workerClosePromises = Array.from(this.workers.values()).map(worker =>
       worker.close().catch(err => this.logger.error(`Error closing worker`, { err })),
     );
@@ -261,7 +259,5 @@ export class QueueService implements OnModuleDestroy {
         .catch(err => this.logger.error(`Error closing Redis connection`, { err }));
       this.redisClient = null;
     }
-
-    this.logger.log('All queues and workers closed');
   }
 }


### PR DESCRIPTION
- Eliminate logging statements during the closure of queues and workers
- Streamline the onModuleDestroy method for better clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Removed two log messages related to queue and worker shutdown processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->