### PR TITLE
feat(workflows-service): update middleware config and port variable

### DIFF
--- a/services/workflows-service/src/app.worker.module.ts
+++ b/services/workflows-service/src/app.worker.module.ts
@@ -1,4 +1,4 @@
-import { MiddlewareConsumer, Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ClsModule } from 'nestjs-cls';
 
@@ -39,6 +39,12 @@ import { MetricsAuthMiddleware } from './common/middlewares/metrics-auth.middlew
 })
 export class WorkerAppModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(MetricsAuthMiddleware).forRoutes('*');
+    consumer
+      .apply(MetricsAuthMiddleware)
+      .exclude(
+        { path: '/_health/ready', method: RequestMethod.GET },
+        { path: '/_health/live', method: RequestMethod.GET },
+      )
+      .forRoutes('*');
   }
 }

--- a/services/workflows-service/src/app.worker.module.ts
+++ b/services/workflows-service/src/app.worker.module.ts
@@ -38,13 +38,4 @@ import { MetricsAuthMiddleware } from './common/middlewares/metrics-auth.middlew
   ],
 })
 export class WorkerAppModule {
-  configure(consumer: MiddlewareConsumer) {
-    consumer
-      .apply(MetricsAuthMiddleware)
-      .exclude(
-        { path: '/_health/ready', method: RequestMethod.GET },
-        { path: '/_health/live', method: RequestMethod.GET },
-      )
-      .forRoutes('*');
-  }
 }

--- a/services/workflows-service/src/main.worker.ts
+++ b/services/workflows-service/src/main.worker.ts
@@ -33,7 +33,7 @@ const workerMain = async () => {
   process.once('SIGINT', () => closeApp('SIGINT'));
   const configService = app.get(ConfigService);
 
-  const port = configService.getOrThrow<string>('PORT');
+  const port = configService.getOrThrow<string>('WORKER_PORT');
   void app.listen(+port);
 
   logger.log(`Listening on port ${port}`);


### PR DESCRIPTION
- Exclude health check routes from middleware
- Change port variable from 'PORT' to 'WORKER_PORT'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Health check endpoints now bypass authentication, improving reliability for readiness and liveness probes.

- **Chores**
  - The worker application now uses a dedicated environment variable for port configuration.
  - Removed authentication middleware from all worker service routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->