### PR TITLE
fix: fixed bug where documents of same category but different type didnt render in dropdown

### DIFF
--- a/apps/backoffice-v2/src/pages/Entity/hooks/useEntityLogic/utils.ts
+++ b/apps/backoffice-v2/src/pages/Entity/hooks/useEntityLogic/utils.ts
@@ -1,4 +1,4 @@
-import { AnyArray, TypesafeOmit } from '../../../../common/types';
+import { TypesafeOmit } from '../../../../common/types';
 import { TDocument } from '@ballerine/common';
 import { titleCase } from 'string-ts';
 import { TDropdownOption } from '@/lib/blocks/components/EditableDetails/types';
@@ -34,8 +34,8 @@ export const composePickableCategoryType = (
     const isCategoryInDropdownOptions = documentCategoryDropdownOptions.some(
       option => option.value === category,
     );
-    const isTypeInDropdownOptions = documentTypesDropdownOptions.some(
-      option => option.value === type,
+    const isTypeWithCategoryInDropdownOptions = documentTypesDropdownOptions.some(
+      option => option.value === type && option.dependantValue === category,
     );
 
     if (category && !isCategoryInDropdownOptions) {
@@ -45,7 +45,7 @@ export const composePickableCategoryType = (
       });
     }
 
-    if (type && !isTypeInDropdownOptions) {
+    if (type && !isTypeWithCategoryInDropdownOptions) {
       documentTypesDropdownOptions.push({
         dependantOn: 'category',
         dependantValue: category,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,10 +79,10 @@ importers:
         specifier: 0.9.118
         version: link:../../packages/common
       '@ballerine/react-pdf-toolkit':
-        specifier: ^1.2.130
+        specifier: ^1.2.131
         version: link:../../packages/react-pdf-toolkit
       '@ballerine/ui':
-        specifier: 0.7.169
+        specifier: 0.7.171
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
         specifier: 0.6.142
@@ -527,7 +527,7 @@ importers:
         specifier: ^0.9.118
         version: link:../../packages/common
       '@ballerine/ui':
-        specifier: 0.7.169
+        specifier: 0.7.171
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
         specifier: 0.6.142
@@ -1525,7 +1525,7 @@ importers:
         specifier: ^1.1.44
         version: link:../config
       '@ballerine/ui':
-        specifier: 0.7.169
+        specifier: 0.7.171
         version: link:../ui
       '@react-pdf/renderer':
         specifier: ^3.1.14


### PR DESCRIPTION
fixed bug where documents of same category but different type didnt render in dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the logic for displaying document type options in dropdowns to ensure each type is uniquely identified by both its value and category, preventing duplicate or incorrect entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->