### PR TITLE
fix(api): update file upload endpoints to match backend controller paths

### DIFF
--- a/apps/kyb-app/src/domains/collection-flow/collection-flow.api.ts
+++ b/apps/kyb-app/src/domains/collection-flow/collection-flow.api.ts
@@ -158,7 +158,7 @@ export const finalSubmissionRequest = async (context?: CollectionFlowContext) =>
 };
 
 export const fetchDocumentsByIds = async (ids: string[]) => {
-  const result = await request.get('collection-flow/files', {
+  const result = await request.get('collection-flow/documents', {
     searchParams: {
       ids: ids.join(','),
     },

--- a/apps/kyb-app/src/domains/storage/storage.api.ts
+++ b/apps/kyb-app/src/domains/storage/storage.api.ts
@@ -6,7 +6,7 @@ export const uploadFile = async (dto: UploadFileDto): Promise<{ id: string }> =>
   formData.append('file', dto.file);
 
   const { id: fileId } = await request
-    .post('collection-flow/files/old', {
+    .post('collection-flow/documents', {
       body: formData,
     })
     .json<{
@@ -19,7 +19,7 @@ export const uploadFile = async (dto: UploadFileDto): Promise<{ id: string }> =>
 };
 
 export const fetchFile = async (fileId: string): Promise<IFile> => {
-  const result = await request.get(`collection-flow/files/${fileId}`);
+  const result = await request.get(`collection-flow/documents/${fileId}`);
 
   return result.json<IFile>();
 };

--- a/sdks/web-ui-sdk/src/lib/configuration/configuration.ts
+++ b/sdks/web-ui-sdk/src/lib/configuration/configuration.ts
@@ -32,7 +32,7 @@ export const configuration: IAppConfiguration = {
       getVerificationStatus: '/v2/enduser/verify/status/{verificationId}',
       processStepData: '/v2/enduser/verify/partial',
       getConfig: '/v2/clients/{clientId}/config',
-      uploadFile: '/collection-flow/files',
+      uploadFile: '/collection-flow/documents',
       updateContext: '/collection-flow/sync/context',
     },
   },


### PR DESCRIPTION
This commit fixes issue #3404 where frontend POST requests to /api/v1/collection-flow/files were returning 404 Not Found errors.

Changes made:
- Updated frontend API calls in storage.api.ts to use 'collection-flow/documents' instead of 'collection-flow/files/old'
- Updated file fetch endpoint to use 'collection-flow/documents/' instead of 'collection-flow/files/'
- Fixed document fetching function in collection-flow.api.ts to use correct 'collection-flow/documents' endpoint
- Updated SDK configuration in configuration.ts to use '/collection-flow/documents' for uploadFile endpoint

The issue was caused by a mismatch between frontend API calls and backend controller endpoints. The backend controller is correctly defined as CollectionFlowDocumentsController with the path 'collection-flow/documents', but frontend was using incorrect paths.

This fix ensures all frontend requests align with the actual backend endpoints, resolving the 404 error when uploading files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated file and document-related API endpoints to use new standardized paths for uploading, fetching, and retrieving documents. No changes to user-facing functionality or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->