### PR TITLE
bal 4328 fix unsubscribe from ongoing monitoring logic to match url

### DIFF
--- a/apps/backoffice-v2/src/domains/business-reports/fetchers.ts
+++ b/apps/backoffice-v2/src/domains/business-reports/fetchers.ts
@@ -28,7 +28,7 @@ export const BusinessReportSchema = ReportSchema.transform(data => {
   return {
     ...data,
     status: data.status in statusOverrides ? statusOverrides[data.status] : data.status,
-    website: data.website.url,
+    website: data.website,
     riskLevel: isReportReady ? data.riskLevel : null,
     data: isReportReady ? data?.data : null,
     isExample: data.metadata?.isExample ?? false,

--- a/apps/backoffice-v2/src/domains/business-reports/utils/format-business-reports-for-csv.ts
+++ b/apps/backoffice-v2/src/domains/business-reports/utils/format-business-reports-for-csv.ts
@@ -168,7 +168,7 @@ export const formatBusinessReportsForCsv = (
       'Merchant ID': report.business?.correlationId || report.business?.id || null,
       'Report ID': report.id || null,
       'Merchant Name': report.companyName || null,
-      'Merchant URL': report.website,
+      'Merchant URL': report.website.url,
       'Risk Level': report.riskLevel || null,
       'Scan Type': REPORT_TYPE_TO_DISPLAY_TEXT[report.reportType] || report.reportType,
       'Monitoring Alert': report.isAlert ? 'Yes' : 'No',

--- a/apps/backoffice-v2/src/pages/IdentityVerification/components/IdentityVerificationChecksStatus/IdentityVerificationChecksStatus.tsx
+++ b/apps/backoffice-v2/src/pages/IdentityVerification/components/IdentityVerificationChecksStatus/IdentityVerificationChecksStatus.tsx
@@ -40,7 +40,7 @@ import { toast } from 'sonner';
 import { t } from 'i18next';
 import { getNoteContentForUnsubscribe } from './helpers/get-note-content-for-unsubscribe';
 import { getBaseNoteContent } from './helpers/get-base-note-content';
-import { useToggleMonitoringMutation } from '@/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation';
+import { useUpdateOngoingMonitoringStatusMutation } from '@/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation';
 import { IdentityVerificationChecksButton } from './IdentityVerificationChecksButton';
 import { useIdentityVerificationDialog } from './hooks/useIdentityVerificationDialog/useIdentityVerificationDialog';
 import { IdentityVerificationChecksBadge } from './IdentityVerificationChecksBadge';
@@ -70,8 +70,8 @@ export const IdentityVerificationChecksStatus = ({
   const { mutate: mutateUpdateReportStatus, isLoading: isUpdatingReportStatus } =
     useUpdateReportStatusMutation();
   const { mutateAsync: turnOffMonitoringMutation, isLoading: isTurningOffMonitoring } =
-    useToggleMonitoringMutation({
-      state: 'off',
+    useUpdateOngoingMonitoringStatusMutation({
+      status: 'inactive',
       onSuccess: () => {
         form.reset();
         toast.success(t(`toast:business_monitoring_off.success`));

--- a/apps/backoffice-v2/src/pages/MerchantMonitoring/components/MerchantMonitoringReportStatus/MerchantMonitoringReportStatus.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoring/components/MerchantMonitoringReportStatus/MerchantMonitoringReportStatus.tsx
@@ -42,7 +42,7 @@ import { toast } from 'sonner';
 import { t } from 'i18next';
 import { getNoteContentForUnsubscribe } from './helpers/get-note-content-for-unsubscribe';
 import { getBaseNoteContent } from './helpers/get-base-note-content';
-import { useToggleMonitoringMutation } from '@/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation';
+import { useUpdateOngoingMonitoringStatusMutation } from '@/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation';
 
 /* TODO: Remove this filtering once completed status is removed */
 const UPDATEABLE_REPORT_STATUSES = _UPDATEABLE_REPORT_STATUSES.filter(
@@ -57,11 +57,11 @@ export const MerchantMonitoringReportStatus = ({
   status,
   reportId,
   className,
-  businessId,
+  websiteId,
 }: {
   reportId?: string;
   className?: string;
-  businessId?: string;
+  websiteId?: string;
   status?: keyof typeof statusToData;
 }) => {
   const { mutateAsync: mutateCreateNote } = useCreateNoteMutation({ disableToast: true });
@@ -69,8 +69,8 @@ export const MerchantMonitoringReportStatus = ({
   const { mutate: mutateUpdateReportStatus, isLoading: isUpdatingReportStatus } =
     useUpdateReportStatusMutation();
   const { mutateAsync: turnOffMonitoringMutation, isLoading: isTurningOffMonitoring } =
-    useToggleMonitoringMutation({
-      state: 'off',
+    useUpdateOngoingMonitoringStatusMutation({
+      status: 'inactive',
       onSuccess: () => {
         form.reset();
         toast.success(t(`toast:business_monitoring_off.success`));
@@ -119,14 +119,14 @@ export const MerchantMonitoringReportStatus = ({
       : getBaseNoteContent(statusReadableText, text);
 
     if (isShouldUnsubscribe) {
-      await turnOffMonitoringMutation(businessId ?? '');
+      await turnOffMonitoringMutation(websiteId ?? '');
     }
 
     mutateUpdateReportStatus({ reportId, status: dialogState.status, text });
 
     void mutateCreateNote({
       content: noteContent,
-      entityId: businessId ?? '',
+      entityId: websiteId ?? '',
       entityType: 'Business',
       noteableId: reportId ?? '',
       noteableType: 'Report',

--- a/apps/backoffice-v2/src/pages/MerchantMonitoring/components/MerchantMonitoringTable/columns.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoring/components/MerchantMonitoringTable/columns.tsx
@@ -194,7 +194,7 @@ export const useColumns = ({ isDemoAccount = false }) => {
           return (
             <ContentTooltip
               description={
-                <p>This merchant is {!value && 'not '}subscribed to recurring ongoing monitoring</p>
+                <p>This website is {!value && 'not '}subscribed to recurring ongoing monitoring</p>
               }
               props={{
                 tooltipTrigger: { className: 'flex w-full justify-start' },
@@ -225,7 +225,7 @@ export const useColumns = ({ isDemoAccount = false }) => {
         },
         header: () => (
           <ContentTooltip
-            description={<p>Indicates whether the merchant is subscribed to ongoing monitoring</p>}
+            description={<p>Indicates whether the website is subscribed to ongoing monitoring</p>}
             props={{
               tooltipTrigger: { className: 'mx-auto' },
               tooltipContent: { align: 'center', side: 'top' },

--- a/apps/backoffice-v2/src/pages/MerchantMonitoring/schemas.ts
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoring/schemas.ts
@@ -93,7 +93,7 @@ export const MerchantMonitoringSearchSchema = BaseSearchSchema.extend({
     .enum([
       'createdAt',
       'updatedAt',
-      'business.website',
+      'business.website.url',
       'business.companyName',
       'business.country',
       'riskLevel',

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/BusinessReportOptionsDropdown.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/BusinessReportOptionsDropdown.tsx
@@ -221,7 +221,7 @@ export const BusinessReportOptionsDropdown: FunctionComponent<
                   throw new Error('Business ID is missing');
                 }
 
-                turnOngoingMonitoringOn(businessReport.business.id, {
+                turnOngoingMonitoringOn(businessReport.website.id, {
                   onSuccess: () => {
                     setIsDeboardModalOpen(false);
                     setIsDropdownOpen(false);

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/MerchantMonitoringBusinessReport.page.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/MerchantMonitoringBusinessReport.page.tsx
@@ -183,7 +183,7 @@ export const MerchantMonitoringBusinessReport: FunctionComponent = () => {
             <MerchantMonitoringReportStatus
               reportId={businessReport?.id}
               status={businessReport?.status}
-              businessId={businessReport?.business.id}
+              websiteId={businessReport?.website.id}
             />
           </div>
           <div className={`text-sm`}>

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/fetchers.ts
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/fetchers.ts
@@ -4,28 +4,26 @@ import { Method } from '@/common/enums';
 import { apiClient } from '@/common/api-client/api-client';
 import { handleZodError } from '@/common/utils/handle-zod-error/handle-zod-error';
 
-export type TurnOngoingMonitoringBody = z.infer<typeof TurnOngoingMonitoringBodySchema>;
-export const TurnOngoingMonitoringBodySchema = z.object({
-  state: z.string(),
+export const UpdateOngoingMonitoringStatusBodySchema = z.object({
+  status: z.enum(['active', 'inactive']),
 });
 
-export type TurnOngoingMonitoringResponse = z.infer<typeof TurnOngoingMonitoringResponseSchema>;
-export const TurnOngoingMonitoringResponseSchema = z.object({
-  state: z.string(),
-});
+export type UpdateOngoingMonitoringStatusBody = z.infer<
+  typeof UpdateOngoingMonitoringStatusBodySchema
+>;
 
-export const turnOngoingMonitoring = async ({
-  merchantId,
+export const updateOngoingMonitoringStatus = async ({
+  websiteId,
   body,
 }: {
-  merchantId: string;
-  body: TurnOngoingMonitoringBody;
+  websiteId: string;
+  body: UpdateOngoingMonitoringStatusBody;
 }) => {
   const [data, error] = await apiClient({
-    endpoint: `../external/businesses/${merchantId}/monitoring`,
+    endpoint: `../external/business-reports/websites/${websiteId}/monitoring`,
     method: Method.PATCH,
     body,
-    schema: TurnOngoingMonitoringResponseSchema,
+    schema: z.undefined(),
     timeout: 300_000,
   });
 

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useMerchantMonitoringBusinessReportLogic/useMerchantMonitoringBusinessReportLogic.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useMerchantMonitoringBusinessReportLogic/useMerchantMonitoringBusinessReportLogic.tsx
@@ -20,7 +20,7 @@ import { useCustomerQuery } from '@/domains/customer/hooks/queries/useCustomerQu
 import { useNotesByNoteable } from '@/domains/notes/hooks/queries/useNotesByNoteable/useNotesByNoteable';
 import { useCreateNoteMutation } from '@/domains/notes/hooks/mutations/useCreateNoteMutation/useCreateNoteMutation';
 import { useBusinessReportByIdQuery } from '@/domains/business-reports/hooks/queries/useBusinessReportByIdQuery/useBusinessReportByIdQuery';
-import { useToggleMonitoringMutation } from '@/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation';
+import { useUpdateOngoingMonitoringStatusMutation } from '@/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation';
 
 const ZodDeboardingSchema = z
   .object({
@@ -85,12 +85,12 @@ export const useMerchantMonitoringBusinessReportLogic = () => {
       throw new Error('Business ID is missing');
     }
 
-    return turnOffMonitoringMutation.mutate(businessReport.business.id);
+    return turnOffMonitoringMutation.mutate(businessReport.website.id);
   };
 
   const { mutateAsync: mutateCreateNote } = useCreateNoteMutation({ disableToast: true });
-  const turnOnMonitoringMutation = useToggleMonitoringMutation({
-    state: 'on',
+  const turnOnMonitoringMutation = useUpdateOngoingMonitoringStatusMutation({
+    status: 'active',
     onSuccess: () => {
       void mutateCreateNote({
         content: 'Monitoring turned on',
@@ -111,8 +111,8 @@ export const useMerchantMonitoringBusinessReportLogic = () => {
     },
   });
 
-  const turnOffMonitoringMutation = useToggleMonitoringMutation({
-    state: 'off',
+  const turnOffMonitoringMutation = useUpdateOngoingMonitoringStatusMutation({
+    status: 'inactive',
     onSuccess: () => {
       const { reason, userReason } = form.getValues();
       const content = [

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useMerchantMonitoringBusinessReportLogic/useMerchantMonitoringBusinessReportLogic.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useMerchantMonitoringBusinessReportLogic/useMerchantMonitoringBusinessReportLogic.tsx
@@ -166,7 +166,7 @@ export const useMerchantMonitoringBusinessReportLogic = () => {
     navigate(-1);
   }, [navigate]);
 
-  const websiteWithNoProtocol = safeUrl(businessReport?.website)?.hostname;
+  const websiteWithNoProtocol = safeUrl(businessReport?.website.url)?.hostname;
   const locale = useLocale();
 
   // Default SPA behavior preserves scroll position on navigation (react-router-dom)

--- a/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation.tsx
+++ b/apps/backoffice-v2/src/pages/MerchantMonitoringBusinessReport/hooks/useToggleMonitoringMutation/useToggleMonitoringMutation.tsx
@@ -2,22 +2,22 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { HttpError } from '@/common/errors/http-error';
-import { turnOngoingMonitoring } from '@/pages/MerchantMonitoringBusinessReport/fetchers';
+import { updateOngoingMonitoringStatus } from '@/pages/MerchantMonitoringBusinessReport/fetchers';
 
-export const useToggleMonitoringMutation = ({
-  state,
+export const useUpdateOngoingMonitoringStatusMutation = ({
+  status,
   onSuccess,
   onError,
 }: {
-  state: 'on' | 'off';
+  status: 'active' | 'inactive';
   onSuccess?: (data: unknown) => void;
   onError?: (error: unknown) => void;
 }) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (merchantId: string) =>
-      turnOngoingMonitoring({ merchantId, body: { state } }),
+    mutationFn: async (websiteId: string) =>
+      updateOngoingMonitoringStatus({ websiteId, body: { status } }),
     onSuccess: data => {
       void queryClient.invalidateQueries();
 

--- a/packages/common/src/schemas/report-schema.ts
+++ b/packages/common/src/schemas/report-schema.ts
@@ -81,7 +81,9 @@ export const ReportSchema = z
     status: z.enum([MERCHANT_REPORT_STATUSES[0]!, ...MERCHANT_REPORT_STATUSES.slice(1)]),
     monitoringStatus: z.boolean().nullish(),
     website: z.object({
+      id: z.string(),
       url: z.string().url(),
+      unsubscribedMonitoringAt: z.string().datetime().nullable(),
     }),
     customer: z.object({
       id: z.string(),
@@ -91,7 +93,6 @@ export const ReportSchema = z
     business: z.object({
       id: z.string(),
       correlationId: z.string().nullish(),
-      unsubscribedMonitoringAt: z.string().datetime().nullable(),
     }),
     metadata: z.record(z.string(), z.unknown()).nullish(),
     companyName: z.string().nullish(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,10 +79,10 @@ importers:
         specifier: 0.9.118
         version: link:../../packages/common
       '@ballerine/react-pdf-toolkit':
-        specifier: ^1.2.130
+        specifier: ^1.2.131
         version: link:../../packages/react-pdf-toolkit
       '@ballerine/ui':
-        specifier: 0.7.169
+        specifier: 0.7.171
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
         specifier: 0.6.142
@@ -527,7 +527,7 @@ importers:
         specifier: ^0.9.118
         version: link:../../packages/common
       '@ballerine/ui':
-        specifier: 0.7.169
+        specifier: 0.7.171
         version: link:../../packages/ui
       '@ballerine/workflow-browser-sdk':
         specifier: 0.6.142
@@ -1525,7 +1525,7 @@ importers:
         specifier: ^1.1.44
         version: link:../config
       '@ballerine/ui':
-        specifier: 0.7.169
+        specifier: 0.7.171
         version: link:../ui
       '@react-pdf/renderer':
         specifier: ^3.1.14

--- a/services/workflows-service/src/business-report/business-report.controller.external.ts
+++ b/services/workflows-service/src/business-report/business-report.controller.external.ts
@@ -42,6 +42,7 @@ import {
 import { BusinessReportMetricsDto } from './dtos/business-report-metrics-dto';
 import { BusinessReportStatusUpdateRequestParamsDto } from '@/business-report/dtos/business-report-status-update.dto';
 import { UserData } from '@/user/user-data.decorator';
+import { OngoingMonitoringPatchDto } from './dtos/ongoing-monitoring.patch.dto';
 
 @ApiBearerAuth()
 @swagger.ApiTags('Business Reports')
@@ -441,5 +442,23 @@ export class BusinessReportControllerExternal {
     res.status(201);
     res.setHeader('content-type', 'application/json');
     res.send(result);
+  }
+
+  @common.Patch('/websites/:websiteId/monitoring')
+  @swagger.ApiForbiddenResponse()
+  @swagger.ApiOkResponse()
+  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
+  async updateOngoingMonitoringState(
+    @common.Param('websiteId') websiteId: string,
+    @common.Body() data: OngoingMonitoringPatchDto,
+    @CurrentProject() currentProjectId: TProjectId,
+  ) {
+    const { id: customerId } = await this.customerService.getByProjectId(currentProjectId);
+
+    await this.merchantMonitoringClient.updateOngoingMonitoring({
+      customerId,
+      websiteId,
+      status: data.status,
+    });
   }
 }

--- a/services/workflows-service/src/business-report/business-report.controller.external.ts
+++ b/services/workflows-service/src/business-report/business-report.controller.external.ts
@@ -159,7 +159,7 @@ export class BusinessReportControllerExternal {
       data: data.map(report => ({
         ...report,
         monitoringStatus:
-          report.customer.ongoingMonitoringEnabled && !report.business.unsubscribedMonitoringAt,
+          report.customer.ongoingMonitoringEnabled && !report.website.unsubscribedMonitoringAt,
       })),
     };
   }
@@ -371,7 +371,7 @@ export class BusinessReportControllerExternal {
     return {
       ...report,
       monitoringStatus:
-        report.customer.ongoingMonitoringEnabled && !report.business.unsubscribedMonitoringAt,
+        report.customer.ongoingMonitoringEnabled && !report.website.unsubscribedMonitoringAt,
     };
   }
 

--- a/services/workflows-service/src/business-report/dtos/ongoing-monitoring.patch.dto.ts
+++ b/services/workflows-service/src/business-report/dtos/ongoing-monitoring.patch.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsIn, IsString } from 'class-validator';
 
-export class BusinessMonitoringPatchDto {
+export class OngoingMonitoringPatchDto {
   @ApiProperty({ type: String, required: true })
   @IsString()
-  @IsIn(['on', 'off'])
-  state!: 'on' | 'off';
+  @IsIn(['active', 'inactive'])
+  status!: 'active' | 'inactive';
 }

--- a/services/workflows-service/src/business/business.controller.external.ts
+++ b/services/workflows-service/src/business/business.controller.external.ts
@@ -5,7 +5,6 @@ import * as swagger from '@nestjs/swagger';
 import { ApiBearerAuth, ApiExcludeEndpoint } from '@nestjs/swagger';
 import { plainToClass } from 'class-transformer';
 import type { Request } from 'express';
-import _ from 'lodash';
 
 import { BusinessInformation } from '@/business/dtos/business-information';
 import { BusinessDto } from '@/business/dtos/business.dto';
@@ -15,7 +14,6 @@ import { CurrentProject } from '@/common/decorators/current-project.decorator';
 import { ProjectIds } from '@/common/decorators/project-ids.decorator';
 import { UseCustomerAuthGuard } from '@/common/decorators/use-customer-auth-guard.decorator';
 import { UseKeyAuthOrSessionGuard } from '@/common/decorators/use-key-auth-or-session-guard.decorator';
-import { FEATURE_LIST, TCustomerWithFeatures } from '@/customer/types';
 import { PrismaService } from '@/prisma/prisma.service';
 import { isRecordNotFoundError } from '@/prisma/prisma.util';
 import type { TProjectId, TProjectIds } from '@/types';
@@ -29,7 +27,6 @@ import { BusinessModel } from './business.model';
 import { BusinessService } from './business.service';
 import { BusinessCreateDto } from './dtos/business-create';
 import { BusinessFindManyArgs } from './dtos/business-find-many-args';
-import { BusinessMonitoringPatchDto } from './dtos/business-monitoring.patch.dto';
 import { BusinessWhereUniqueInput } from './dtos/business-where-unique-input';
 
 @ApiBearerAuth()
@@ -130,42 +127,6 @@ export class BusinessControllerExternal {
             ? JSON.stringify(data.shareholderStructure)
             : undefined,
         projectId: currentProjectId,
-      },
-    });
-  }
-
-  @common.Patch('/:id/monitoring')
-  @swagger.ApiForbiddenResponse()
-  @swagger.ApiOkResponse({ type: BusinessDto })
-  @swagger.ApiNotFoundResponse({ type: errors.NotFoundException })
-  async updateOngoingMonitoringState(
-    @common.Param('id') businessId: string,
-    @common.Body() data: BusinessMonitoringPatchDto,
-    @CurrentProject() currentProjectId: TProjectId,
-  ) {
-    const business = await this.businessService.getById(
-      businessId,
-      { select: { metadata: true } },
-      [currentProjectId],
-    );
-
-    const metadata = business?.metadata as {
-      featureConfig?: TCustomerWithFeatures['features'];
-    };
-
-    const isEnabled = data.state === 'on';
-    const updatedMetadata = _.merge({}, metadata, {
-      featureConfig: {
-        [FEATURE_LIST.ONGOING_MERCHANT_REPORT]: {
-          enabled: isEnabled,
-          disabledAt: isEnabled ? null : new Date().getTime(),
-        },
-      },
-    });
-
-    await this.businessService.updateById(businessId, {
-      data: {
-        metadata: updatedMetadata,
       },
     });
   }

--- a/services/workflows-service/src/common/utils/unified-api-client/unified-api-client.ts
+++ b/services/workflows-service/src/common/utils/unified-api-client/unified-api-client.ts
@@ -165,24 +165,11 @@ export class UnifiedApiClient {
   }
 
   public formatBusiness(business: BusinessPayload) {
-    const metadata = business.metadata as unknown as {
-      featureConfig: TCustomerWithFeatures['features'];
-      lastOngoingReportInvokedAt: number;
-    } | null;
-
-    const unsubscribedMonitoringAt = metadata?.featureConfig?.[FEATURE_LIST.ONGOING_MERCHANT_REPORT]
-      ?.disabledAt
-      ? new Date(metadata.featureConfig[FEATURE_LIST.ONGOING_MERCHANT_REPORT]!.disabledAt!)
-      : metadata?.featureConfig?.[FEATURE_LIST.ONGOING_MERCHANT_REPORT]?.enabled === false
-      ? new Date()
-      : null;
-
     return {
       id: business.id,
       correlationId: business.correlationId,
       companyName: business.companyName,
       customerId: business.project.customer.id,
-      unsubscribedMonitoringAt: unsubscribedMonitoringAt?.toISOString() ?? null,
       createdAt: business.createdAt.toISOString(),
       updatedAt: business.updatedAt.toISOString(),
     };

--- a/services/workflows-service/src/merchant-monitoring/merchant-monitoring.client.ts
+++ b/services/workflows-service/src/merchant-monitoring/merchant-monitoring.client.ts
@@ -273,6 +273,20 @@ export class MerchantMonitoringClient {
     });
   }
 
+  public async updateOngoingMonitoring({
+    customerId,
+    websiteId,
+    status,
+  }: {
+    customerId: string;
+    websiteId: string;
+    status: 'active' | 'inactive';
+  }) {
+    await this.axios.put(`customers/${customerId}/websites/${websiteId}`, {
+      unsubscribedMonitoringAt: status === 'active' ? null : new Date().toISOString(),
+    });
+  }
+
   public async getMetrics({
     customerId,
     from,


### PR DESCRIPTION
- **feat(monitoring): implement ongoing monitoring state update functionality**
- **refactor(business-reports): update terminology and structures for monitoring**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to update ongoing monitoring status directly for websites, including a new API endpoint for this action.

* **Improvements**
  * Monitoring status management now uses website identifiers instead of business identifiers throughout the interface.
  * Tooltips and labels updated to reference "website" instead of "merchant" for improved clarity.
  * Monitoring status toggling now uses clearer "active"/"inactive" terminology instead of "on"/"off".
  * Enhanced business report schema to include monitoring status fields at the website level.
  * CSV exports and sorting options updated to reflect website URL properties accurately.

* **Bug Fixes**
  * Monitoring status checks and updates now consistently reference website-level data, ensuring accurate status display and management.

* **Refactor**
  * Removed outdated business-level monitoring update routes and logic.
  * Updated and renamed data structures, API calls, and mutation hooks to align with website-based monitoring management.
  * Simplified internal business data formatting by removing obsolete monitoring unsubscribe date logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->